### PR TITLE
HTML docstage/doctype layout conflict fix

### DIFF
--- a/lib/isodoc/iso/html/style-human.scss
+++ b/lib/isodoc/iso/html/style-human.scss
@@ -317,14 +317,17 @@ div.figure {
 */
 
 .document-type-band {
-    @include docBand(2, 100%, 180px);
+    @include docBand($order: 2, $offset: 180px);
+
+    .document-type {
+        top: 20px;
+    }
 }
 
 .document-stage-band {
     @include docBand(1, 100%);
 }
 
-p.document-type,
 p.document-stage {
     @include docBandTitle(210px);
     writing-mode: vertical-rl;

--- a/lib/isodoc/iso/html/style-iso.scss
+++ b/lib/isodoc/iso/html/style-iso.scss
@@ -263,14 +263,17 @@ div.figure {
 */
 
 .document-type-band {
-    @include docBand(2, 100%, 180px);
+    @include docBand($order: 2, $offset: 180px);
+
+    .document-type {
+        top: 20px;
+    }
 }
 
 .document-stage-band {
     @include docBand(1, 100%);
 }
 
-p.document-type,
 p.document-stage {
     @include docBandTitle(210px);
     writing-mode: vertical-rl;


### PR DESCRIPTION
metanorma/metanorma-ogc#128:

HTML docstage/doctype layout conflict fix,
Use new format docBand isodoc mixin 