### PR TITLE
Intelligent term references and formatting

### DIFF
--- a/lib/asciidoctor/iso/base.rb
+++ b/lib/asciidoctor/iso/base.rb
@@ -6,12 +6,17 @@ require "open-uri"
 require "pp"
 require "isodoc"
 require "fileutils"
+require 'asciidoctor/iso/macros'
 
 module Asciidoctor
   module ISO
     class Converter < Standoc::Converter
       XML_ROOT_TAG = "iso-standard".freeze
       XML_NAMESPACE = "https://www.metanorma.org/ns/iso".freeze
+
+      Asciidoctor::Extensions.register do
+        inline_macro Asciidoctor::Iso::TermRefInlineMacro
+      end
 
       def html_converter(node)
         IsoDoc::Iso::HtmlConvert.new(html_extract_attributes(node))

--- a/lib/asciidoctor/iso/cleanup.rb
+++ b/lib/asciidoctor/iso/cleanup.rb
@@ -20,7 +20,7 @@ module Asciidoctor
         "//annex//fn | "\
         "//references[title = 'Bibliography']//fn".freeze
 
-      AUTOMATIC_GENERATED_ID_REGEXP = /\A_/.freeze
+      AUTOMATIC_GENERATED_ID_REGEXP = /\A_/
 
       def other_footnote_renumber(xmldoc)
         seen = {}

--- a/lib/asciidoctor/iso/cleanup.rb
+++ b/lib/asciidoctor/iso/cleanup.rb
@@ -97,7 +97,12 @@ module Asciidoctor
         termlookup = replace_automatic_genrated_ids_terms(xmldoc)
         xmldoc.xpath('//termxref').each do |node|
           target = node.text
-          next if termlookup[target].nil?
+          if termlookup[target].nil?
+            @log.add("AsciiDoc Input",
+                     node,
+                     "#{target} does not refer to a real term")
+            next
+          end
 
           node.name = 'xref'
           node['target'] = termlookup[target]
@@ -115,11 +120,11 @@ module Asciidoctor
       end
 
       def unique_text_id(xmldoc, text)
-        return "text-#{text}" if xmldoc.at("//*[@id = 'text-#{text}']").nil?
+        return "term-#{text}" if xmldoc.at("//*[@id = 'term-#{text}']").nil?
 
         (1..Float::INFINITY).lazy.each do |index|
-          if xmldoc.at("//*[@id = 'text-#{text}-#{index}']").nil?
-            break("text-#{text}-#{index}")
+          if xmldoc.at("//*[@id = 'term-#{text}-#{index}']").nil?
+            break("term-#{text}-#{index}")
           end
         end
       end

--- a/lib/asciidoctor/iso/macros.rb
+++ b/lib/asciidoctor/iso/macros.rb
@@ -1,0 +1,17 @@
+require 'asciidoctor/extensions'
+
+module Asciidoctor
+  module Iso
+    class TermRefInlineMacro < Asciidoctor::Extensions::InlineMacroProcessor
+      use_dsl
+
+      named :term
+      name_positional_attributes 'name', 'termxref'
+      using_format :short
+
+      def process(parent, target, attrs)
+        "<em>#{attrs['name']}</em> (<termxref>#{attrs['termxref'] || attrs['name']}</termxref>)"
+      end
+    end
+  end
+end

--- a/lib/asciidoctor/iso/macros.rb
+++ b/lib/asciidoctor/iso/macros.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require 'asciidoctor/extensions'
 
 module Asciidoctor
   module Iso
+    # Macro to transform `term[X,Y]` into em, termxref xml
     class TermRefInlineMacro < Asciidoctor::Extensions::InlineMacroProcessor
       use_dsl
 
@@ -9,8 +12,9 @@ module Asciidoctor
       name_positional_attributes 'name', 'termxref'
       using_format :short
 
-      def process(parent, target, attrs)
-        "<em>#{attrs['name']}</em> (<termxref>#{attrs['termxref'] || attrs['name']}</termxref>)"
+      def process(_parent, _target, attrs)
+        termref = attrs['termxref'] || attrs['name']
+        "<em>#{attrs['name']}</em> (<termxref>#{termref}</termxref>)"
       end
     end
   end

--- a/spec/asciidoctor-iso/blocks_spec.rb
+++ b/spec/asciidoctor-iso/blocks_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Asciidoctor::ISO do
       #{ASCIIDOC_BLANK_HDR}
       [stem]
       ++++
-      r = 1 % 
-      r = 1 % 
+      r = 1 %
+      r = 1 %
       ++++
 
       [stem]
@@ -113,7 +113,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="text-Term1">
          <preferred>Term1</preferred>
          <termnote id="_">
          <p id="_">This is a note</p>
@@ -223,7 +223,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="text-Term1">
          <preferred>Term1</preferred>
          <termexample id="_">
          <p id="_">This is an example</p>
@@ -428,7 +428,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="text-Term1">
          <preferred>Term1</preferred>
          <termsource status="identical">
          <origin bibitemid="ISO2191" type="inline" citeas="">
@@ -459,7 +459,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="text-Term1">
          <preferred>Term1</preferred>
          <termsource status="modified">
          <origin bibitemid="ISO2191" type="inline" citeas="">

--- a/spec/asciidoctor-iso/blocks_spec.rb
+++ b/spec/asciidoctor-iso/blocks_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="text-Term1">
+         <term id="term-Term1">
          <preferred>Term1</preferred>
          <termnote id="_">
          <p id="_">This is a note</p>
@@ -223,7 +223,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="text-Term1">
+         <term id="term-Term1">
          <preferred>Term1</preferred>
          <termexample id="_">
          <p id="_">This is an example</p>
@@ -428,7 +428,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="text-Term1">
+         <term id="term-Term1">
          <preferred>Term1</preferred>
          <termsource status="identical">
          <origin bibitemid="ISO2191" type="inline" citeas="">
@@ -459,7 +459,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="text-Term1">
+         <term id="term-Term1">
          <preferred>Term1</preferred>
          <termsource status="modified">
          <origin bibitemid="ISO2191" type="inline" citeas="">

--- a/spec/asciidoctor-iso/cleanup_spec.rb
+++ b/spec/asciidoctor-iso/cleanup_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="text-t90"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><admitted><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>91</mn></msub></math></stem></admitted>
+         <term id="term-t90"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><admitted><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>91</mn></msub></math></stem></admitted>
        <definition><p id="_">Time</p></definition></term>
        </terms>
        </sections>
@@ -54,7 +54,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="text-Tempus">
+         <term id="term-Tempus">
          <preferred>Tempus</preferred>
          <domain>relativity</domain><definition><p id="_"> Time</p></definition>
        </term>
@@ -90,7 +90,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="text-t90"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><definition><formula id="_">
+         <term id="term-t90"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><definition><formula id="_">
          <stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mi>A</mi></msub></math></stem>
        </formula><p id="_">This paragraph is extraneous</p></definition>
        </term>
@@ -118,7 +118,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative"><title>Terms and definitions</title>
 
          #{TERM_BOILERPLATE}
-       <term id="text-Time">
+       <term id="term-Time">
        <preferred>Time</preferred>
          <definition><p id="_">This paragraph is extraneous</p></definition>
        </term></terms>
@@ -305,7 +305,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="text-Term1">
+         <term id="term-Term1">
          <preferred>Term1</preferred>
          <termsource status="identical">
          <origin bibitemid="ISO2191" type="inline" citeas="">

--- a/spec/asciidoctor-iso/cleanup_spec.rb
+++ b/spec/asciidoctor-iso/cleanup_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><admitted><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>91</mn></msub></math></stem></admitted>
+         <term id="text-t90"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><admitted><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>91</mn></msub></math></stem></admitted>
        <definition><p id="_">Time</p></definition></term>
        </terms>
        </sections>
@@ -54,7 +54,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="text-Tempus">
          <preferred>Tempus</preferred>
          <domain>relativity</domain><definition><p id="_"> Time</p></definition>
        </term>
@@ -90,7 +90,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><definition><formula id="_">
+         <term id="text-t90"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><definition><formula id="_">
          <stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mi>A</mi></msub></math></stem>
        </formula><p id="_">This paragraph is extraneous</p></definition>
        </term>
@@ -118,7 +118,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative"><title>Terms and definitions</title>
 
          #{TERM_BOILERPLATE}
-       <term id="_">
+       <term id="text-Time">
        <preferred>Time</preferred>
          <definition><p id="_">This paragraph is extraneous</p></definition>
        </term></terms>
@@ -305,7 +305,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="text-Term1">
          <preferred>Term1</preferred>
          <termsource status="identical">
          <origin bibitemid="ISO2191" type="inline" citeas="">
@@ -753,7 +753,7 @@ RSpec.describe Asciidoctor::ISO do
   it "reorders references in bibliography, and renumbers citations accordingly" do
     expect(xmlpp(strip_guid(Asciidoctor.convert(<<~"INPUT", backend: :iso, header_footer: true)))).to be_equivalent_to xmlpp(<<~"OUTPUT")
     #{ASCIIDOC_BLANK_HDR}
-    
+
     == Clause 1
     <<ref1>>
     <<ref1a>>

--- a/spec/asciidoctor-iso/macros_spec.rb
+++ b/spec/asciidoctor-iso/macros_spec.rb
@@ -18,4 +18,208 @@ RSpec.describe Asciidoctor::ISO do
     OUTPUT
   end
 
+  describe 'term inline macros' do
+    subject(:convert) { xmlpp(strip_guid(Asciidoctor.convert(input, backend: :iso, header_footer: true))) }
+    let(:input) do
+      <<~XML
+        #{ASCIIDOC_BLANK_HDR}
+        == Terms and Definitions
+
+        === name2
+
+        == Main
+
+        term:[name,name2]
+      XML
+    end
+    let(:output) do
+      <<~XML
+        #{BLANK_HDR}
+        <sections>
+          <terms id='_' obligation='normative'>
+            <title>Terms and definitions</title>
+            <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
+            <p id='_'>
+              ISO and IEC maintain terminological databases for use in standardization
+              at the following addresses:
+            </p>
+            <ul id='_'>
+              <li>
+                <p id='_'>
+                  ISO Online browsing platform: available at
+                  <link target='http://www.iso.org/obp'/>
+                </p>
+              </li>
+              <li>
+                <p id='_'>
+                  IEC Electropedia: available at
+                  <link target='http://www.electropedia.org'/>
+                </p>
+              </li>
+            </ul>
+            <term id='text-name2'>
+              <preferred>name2</preferred>
+            </term>
+          </terms>
+          <clause id='_' inline-header='false' obligation='normative'>
+            <title>Main</title>
+            <p id='_'>
+              <em>name</em>
+              (
+              <xref target='text-name2'>name2</xref>
+              )
+            </p>
+          </clause>
+        </sections>
+        </iso-standard>
+      XML
+    end
+
+    it 'converts macro into the correct xml' do
+      expect(convert).to(be_equivalent_to(xmlpp(output)))
+    end
+
+    context 'default params' do
+      let(:input) do
+        <<~XML
+          #{ASCIIDOC_BLANK_HDR}
+
+          == Terms and Definitions
+
+          === name
+
+          == Main
+
+          term:[name]
+        XML
+      end
+      let(:output) do
+        <<~XML
+          #{BLANK_HDR}
+          <sections>
+            <terms id='_' obligation='normative'>
+              <title>Terms and definitions</title>
+              <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
+              <p id='_'>
+                ISO and IEC maintain terminological databases for use in standardization
+                at the following addresses:
+              </p>
+              <ul id='_'>
+                <li>
+                  <p id='_'>
+                    ISO Online browsing platform: available at
+                    <link target='http://www.iso.org/obp' />
+                  </p>
+                </li>
+                <li>
+                  <p id='_'>
+                    IEC Electropedia: available at
+                    <link target='http://www.electropedia.org' />
+                  </p>
+                </li>
+              </ul>
+              <term id='text-name'>
+                <preferred>name</preferred>
+              </term>
+            </terms>
+            <clause id='_' inline-header='false' obligation='normative'>
+              <title>Main</title>
+              <p id='_'>
+                <em>name</em>
+                (
+                <xref target='text-name'>name</xref>
+                )
+              </p>
+            </clause>
+          </sections>
+          </iso-standard>
+        XML
+      end
+
+      it 'uses `name` as termref name' do
+        expect(convert).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'multiply exising ids in document' do
+      let(:input) do
+        <<~XML
+          #{ASCIIDOC_BLANK_HDR}
+
+          == Terms and Definitions
+
+          === name
+          === name2
+
+          [[text-name]]
+          == Main
+
+          paragraph
+
+          [[text-name2]]
+          == Second
+
+          term:[name]
+          term:[name2]
+        XML
+      end
+      let(:output) do
+        <<~XML
+          #{BLANK_HDR}
+          <sections>
+            <terms id='_' obligation='normative'>
+              <title>Terms and definitions</title>
+              <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
+              <p id='_'>
+                ISO and IEC maintain terminological databases for use in standardization
+                at the following addresses:
+              </p>
+              <ul id='_'>
+                <li>
+                  <p id='_'>
+                    ISO Online browsing platform: available at
+                    <link target='http://www.iso.org/obp' />
+                  </p>
+                </li>
+                <li>
+                  <p id='_'>
+                    IEC Electropedia: available at
+                    <link target='http://www.electropedia.org' />
+                  </p>
+                </li>
+              </ul>
+              <term id='text-name-1'>
+                <preferred>name</preferred>
+              </term>
+              <term id='text-name2-1'>
+                <preferred>name2</preferred>
+              </term>
+            </terms>
+            <clause id='text-name' inline-header='false' obligation='normative'>
+              <title>Main</title>
+              <p id='_'>paragraph</p>
+            </clause>
+            <clause id='text-name2' inline-header='false' obligation='normative'>
+              <title>Second</title>
+              <p id='_'>
+                <em>name</em>
+                (
+                <xref target='text-name-1'>name</xref>
+                )
+                <em>name2</em>
+                  (
+                <xref target='text-name2-1'>name2</xref>
+                )
+              </p>
+            </clause>
+          </sections>
+          </iso-standard>
+        XML
+      end
+
+      it 'generates unique ids which dont match existing ids' do
+        expect(convert).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+  end
 end

--- a/spec/asciidoctor-iso/macros_spec.rb
+++ b/spec/asciidoctor-iso/macros_spec.rb
@@ -19,7 +19,11 @@ RSpec.describe Asciidoctor::ISO do
   end
 
   describe 'term inline macros' do
-    subject(:convert) { xmlpp(strip_guid(Asciidoctor.convert(input, backend: :iso, header_footer: true))) }
+    subject(:convert) do
+      xmlpp(
+        strip_guid(
+          Asciidoctor.convert(input, backend: :iso, header_footer: true)))
+    end
     let(:input) do
       <<~XML
         #{ASCIIDOC_BLANK_HDR}

--- a/spec/asciidoctor-iso/macros_spec.rb
+++ b/spec/asciidoctor-iso/macros_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Asciidoctor::ISO do
                 </p>
               </li>
             </ul>
-            <term id='text-name2'>
+            <term id='term-name2'>
               <preferred>name2</preferred>
             </term>
           </terms>
@@ -71,7 +71,7 @@ RSpec.describe Asciidoctor::ISO do
             <p id='_'>
               <em>name</em>
               (
-              <xref target='text-name2'>name2</xref>
+              <xref target='term-name2'>name2</xref>
               )
             </p>
           </clause>
@@ -123,7 +123,7 @@ RSpec.describe Asciidoctor::ISO do
                   </p>
                 </li>
               </ul>
-              <term id='text-name'>
+              <term id='term-name'>
                 <preferred>name</preferred>
               </term>
             </terms>
@@ -132,7 +132,7 @@ RSpec.describe Asciidoctor::ISO do
               <p id='_'>
                 <em>name</em>
                 (
-                <xref target='text-name'>name</xref>
+                <xref target='term-name'>name</xref>
                 )
               </p>
             </clause>
@@ -156,12 +156,12 @@ RSpec.describe Asciidoctor::ISO do
           === name
           === name2
 
-          [[text-name]]
+          [[term-name]]
           == Main
 
           paragraph
 
-          [[text-name2]]
+          [[term-name2]]
           == Second
 
           term:[name]
@@ -193,27 +193,27 @@ RSpec.describe Asciidoctor::ISO do
                   </p>
                 </li>
               </ul>
-              <term id='text-name-1'>
+              <term id='term-name-1'>
                 <preferred>name</preferred>
               </term>
-              <term id='text-name2-1'>
+              <term id='term-name2-1'>
                 <preferred>name2</preferred>
               </term>
             </terms>
-            <clause id='text-name' inline-header='false' obligation='normative'>
+            <clause id='term-name' inline-header='false' obligation='normative'>
               <title>Main</title>
               <p id='_'>paragraph</p>
             </clause>
-            <clause id='text-name2' inline-header='false' obligation='normative'>
+            <clause id='term-name2' inline-header='false' obligation='normative'>
               <title>Second</title>
               <p id='_'>
                 <em>name</em>
                 (
-                <xref target='text-name-1'>name</xref>
+                <xref target='term-name-1'>name</xref>
                 )
                 <em>name2</em>
                   (
-                <xref target='text-name2-1'>name2</xref>
+                <xref target='term-name2-1'>name2</xref>
                 )
               </p>
             </clause>

--- a/spec/asciidoctor-iso/macros_spec.rb
+++ b/spec/asciidoctor-iso/macros_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Asciidoctor::ISO do
     subject(:convert) do
       xmlpp(
         strip_guid(
-          Asciidoctor.convert(input, backend: :iso, header_footer: true)))
+          Asciidoctor.convert(
+            input, backend: :iso, header_footer: true)))
     end
     let(:input) do
       <<~XML

--- a/spec/asciidoctor-iso/section_spec.rb
+++ b/spec/asciidoctor-iso/section_spec.rb
@@ -84,7 +84,7 @@ standardization at the following addresses:</p>
 <link target="http://www.electropedia.org"/>
 </p> </li> </ul>
 
-         <term id="text-Term1">
+         <term id="term-Term1">
          <preferred>Term1</preferred>
        </term>
        </terms>
@@ -109,7 +109,7 @@ standardization at the following addresses:</p>
   </li>
 </ul>
          <title>Normal Terms</title>
-         <term id="text-Term2">
+         <term id="term-Term2">
          <preferred>Term2</preferred>
        </term>
        </terms>
@@ -259,7 +259,7 @@ standardization at the following addresses:</p>
 <link target="http://www.electropedia.org"/>
 </p> </li> </ul>
 
-  <term id="text-Term1">
+  <term id="term-Term1">
   <preferred>Term1</preferred>
 </term>
        </terms></sections>

--- a/spec/asciidoctor-iso/section_spec.rb
+++ b/spec/asciidoctor-iso/section_spec.rb
@@ -84,7 +84,7 @@ standardization at the following addresses:</p>
 <link target="http://www.electropedia.org"/>
 </p> </li> </ul>
 
-         <term id="_">
+         <term id="text-Term1">
          <preferred>Term1</preferred>
        </term>
        </terms>
@@ -109,7 +109,7 @@ standardization at the following addresses:</p>
   </li>
 </ul>
          <title>Normal Terms</title>
-         <term id="_">
+         <term id="text-Term2">
          <preferred>Term2</preferred>
        </term>
        </terms>
@@ -247,7 +247,7 @@ standardization at the following addresses:</p>
          <p id="_">Foreword</p>
        </foreword></preface><sections>
        <terms id="_" obligation="normative">
-          <title>Terms and definitions</title><p id="_">For the purposes of this document, the terms and definitions 
+          <title>Terms and definitions</title><p id="_">For the purposes of this document, the terms and definitions
   given in <eref bibitemid="iso1234"/> and <eref bibitemid="iso5678"/> and the following apply.</p>
   <p id="_">ISO and IEC maintain terminological databases for use in
 standardization at the following addresses:</p>
@@ -259,7 +259,7 @@ standardization at the following addresses:</p>
 <link target="http://www.electropedia.org"/>
 </p> </li> </ul>
 
-  <term id="_">
+  <term id="text-Term1">
   <preferred>Term1</preferred>
 </term>
        </terms></sections>
@@ -296,13 +296,13 @@ standardization at the following addresses:</p>
               <ul id='_'>
                 <li>
                   <p id='_'>
-                    ISO Online browsing platform: available at 
+                    ISO Online browsing platform: available at
                     <link target='http://www.iso.org/obp'/>
                   </p>
                 </li>
                 <li>
                   <p id='_'>
-                    IEC Electropedia: available at 
+                    IEC Electropedia: available at
                     <link target='http://www.electropedia.org'/>
                   </p>
                 </li>


### PR DESCRIPTION
#255 

New macro: `term[X,Y]`, reference term definition throughout the document.