### PR TITLE
Fix up `term:[X]` term referencing and formatting function

### DIFF
--- a/lib/asciidoctor/iso/base.rb
+++ b/lib/asciidoctor/iso/base.rb
@@ -6,12 +6,17 @@ require "open-uri"
 require "pp"
 require "isodoc"
 require "fileutils"
+require 'asciidoctor/iso/macros'
 
 module Asciidoctor
   module ISO
     class Converter < Standoc::Converter
       XML_ROOT_TAG = "iso-standard".freeze
       XML_NAMESPACE = "https://www.metanorma.org/ns/iso".freeze
+
+      Asciidoctor::Extensions.register do
+        inline_macro Asciidoctor::Iso::TermRefInlineMacro
+      end
 
       def html_converter(node)
         IsoDoc::Iso::HtmlConvert.new(html_extract_attributes(node))

--- a/lib/asciidoctor/iso/cleanup.rb
+++ b/lib/asciidoctor/iso/cleanup.rb
@@ -5,6 +5,7 @@ require "json"
 require "pathname"
 require "open-uri"
 require "pp"
+require "asciidoctor/iso/term_lookup_cleanup"
 
 module Asciidoctor
   module ISO
@@ -86,6 +87,11 @@ module Asciidoctor
         bib.sort do |a, b|
           sort_biblio_key(a) <=> sort_biblio_key(b)
         end
+      end
+
+      def termdef_cleanup(xmldoc)
+        Asciidoctor::ISO::TermLookupCleanup.new(xmldoc, @log).call
+        super
       end
 
       # TODO sort by authors

--- a/lib/asciidoctor/iso/macros.rb
+++ b/lib/asciidoctor/iso/macros.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'asciidoctor/extensions'
+
+module Asciidoctor
+  module Iso
+    # Macro to transform `term[X,Y]` into em, termxref xml
+    class TermRefInlineMacro < Asciidoctor::Extensions::InlineMacroProcessor
+      use_dsl
+
+      named :term
+      name_positional_attributes 'name', 'termxref'
+      using_format :short
+
+      def process(_parent, _target, attrs)
+        termref = attrs['termxref'] || attrs['name']
+        defaultref = attrs['termxref'].nil? ? nil : ' defaultref'
+        "<em>#{attrs['name']}</em> (<termxref#{defaultref}>#{termref}</termxref>)"
+      end
+    end
+  end
+end

--- a/lib/asciidoctor/iso/macros.rb
+++ b/lib/asciidoctor/iso/macros.rb
@@ -14,7 +14,7 @@ module Asciidoctor
 
       def process(_parent, _target, attrs)
         termref = attrs['termxref'] || attrs['name']
-        defaultref = attrs['termxref'].nil? ? nil : ' defaultref'
+        defaultref = attrs['termxref'].nil? ? ' defaultref' : ''
         "<em>#{attrs['name']}</em> (<termxref#{defaultref}>#{termref}</termxref>)"
       end
     end

--- a/lib/asciidoctor/iso/term_lookup_cleanup.rb
+++ b/lib/asciidoctor/iso/term_lookup_cleanup.rb
@@ -1,0 +1,79 @@
+module Asciidoctor
+  module ISO
+    # Intelligent term lookup xml modifier
+    # Lookup all `term` and `calause` tags and replace `termxref` tags with
+    # `xref`:target tag
+    class TermLookupCleanup
+      AUTOMATIC_GENERATED_ID_REGEXP = /\A_/
+      EXISTING_TERM_REGEXP = /\Aterm-/
+
+      attr_reader :xmldoc, :termlookup, :log
+
+      def initialize(xmldoc, log)
+        @xmldoc = xmldoc
+        @log = log
+        @termlookup = {}
+      end
+
+      def call
+        @termlookup = replace_automatic_generated_ids_terms
+                      .merge(existing_terms)
+        set_termxref_tags_target
+      end
+
+      private
+
+      def set_termxref_tags_target
+        xmldoc.xpath('//termxref').each do |node|
+          target = node.text
+          # require 'byebug'
+          # byebug
+          if termlookup[target].nil?
+            log.add("AsciiDoc Input",
+                    node,
+                    "#{target} does not refer to a real term")
+            next
+          end
+
+          node.name = 'xref'
+          node['target'] = termlookup[target]
+          # Support for automatic clause numbering, delete text from xref
+          if node['defaultref']
+            node.children.remove
+            node.remove_attribute('defaultref')
+          end
+        end
+      end
+
+      def existing_terms
+        xmldoc.xpath('//clause').each.with_object({}) do |term_node, res|
+          next if term_node['id'].match(EXISTING_TERM_REGEXP).nil?
+
+          res[term_node.at('./title').text] = term_node['id']
+        end
+      end
+
+      def replace_automatic_generated_ids_terms
+        xmldoc.xpath('//term').each.with_object({}) do |term_node, res|
+          # require 'byebug'
+          # byebug
+          next if AUTOMATIC_GENERATED_ID_REGEXP.match(term_node['id']).nil?
+
+          term_text = term_node.at('./preferred').text
+          term_node['id'] = unique_text_id(term_text)
+          res[term_text] = term_node['id']
+        end
+      end
+
+      def unique_text_id(text)
+        return "term-#{text}" if xmldoc.at("//*[@id = 'term-#{text}']").nil?
+
+        (1..Float::INFINITY).lazy.each do |index|
+          if xmldoc.at("//*[@id = 'term-#{text}-#{index}']").nil?
+            break("term-#{text}-#{index}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/asciidoctor/iso/term_lookup_cleanup.rb
+++ b/lib/asciidoctor/iso/term_lookup_cleanup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true.
+
 module Asciidoctor
   module ISO
     # Intelligent term lookup xml modifier
@@ -26,19 +28,21 @@ module Asciidoctor
         xmldoc.xpath('//termxref').each do |node|
           target = normalize_ref_id(node.text)
           if termlookup[target].nil?
-            log.add("AsciiDoc Input",
-                    node,
-                    "#{target} does not refer to a real term")
+            log.add('AsciiDoc Input', node, "#{target} does not refer to a real term")
             next
           end
 
-          node.name = 'xref'
-          node['target'] = termlookup[target]
-          # Support for automatic clause numbering, delete text from xref
-          if node['defaultref']
-            node.children.remove
-            node.remove_attribute('defaultref')
-          end
+          modify_ref_node(node, target)
+        end
+      end
+
+      def modify_ref_node(node, target)
+        node.name = 'xref'
+        node['target'] = termlookup[target]
+        # Support for automatic clause numbering, delete text from xref
+        if node['defaultref']
+          node.children.remove
+          node.remove_attribute('defaultref')
         end
       end
 

--- a/spec/asciidoctor-iso/blocks_spec.rb
+++ b/spec/asciidoctor-iso/blocks_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Asciidoctor::ISO do
       #{ASCIIDOC_BLANK_HDR}
       [stem]
       ++++
-      r = 1 % 
-      r = 1 % 
+      r = 1 %
+      r = 1 %
       ++++
 
       [stem]
@@ -113,7 +113,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="term-term1">
          <preferred>Term1</preferred>
          <termnote id="_">
          <p id="_">This is a note</p>
@@ -223,7 +223,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="term-term1">
          <preferred>Term1</preferred>
          <termexample id="_">
          <p id="_">This is an example</p>
@@ -428,7 +428,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="term-term1">
          <preferred>Term1</preferred>
          <termsource status="identical">
          <origin bibitemid="ISO2191" type="inline" citeas="">
@@ -459,7 +459,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="term-term1">
          <preferred>Term1</preferred>
          <termsource status="modified">
          <origin bibitemid="ISO2191" type="inline" citeas="">

--- a/spec/asciidoctor-iso/cleanup_spec.rb
+++ b/spec/asciidoctor-iso/cleanup_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><admitted><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>91</mn></msub></math></stem></admitted>
+         <term id="term-t90"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><admitted><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>91</mn></msub></math></stem></admitted>
        <definition><p id="_">Time</p></definition></term>
        </terms>
        </sections>
@@ -54,7 +54,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="term-tempus">
          <preferred>Tempus</preferred>
          <domain>relativity</domain><definition><p id="_"> Time</p></definition>
        </term>
@@ -90,7 +90,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><definition><formula id="_">
+         <term id="term-t90"><preferred><stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mn>90</mn></msub></math></stem></preferred><definition><formula id="_">
          <stem type="MathML"><math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mi>t</mi><mi>A</mi></msub></math></stem>
        </formula><p id="_">This paragraph is extraneous</p></definition>
        </term>
@@ -118,7 +118,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative"><title>Terms and definitions</title>
 
          #{TERM_BOILERPLATE}
-       <term id="_">
+       <term id="term-time">
        <preferred>Time</preferred>
          <definition><p id="_">This paragraph is extraneous</p></definition>
        </term></terms>
@@ -305,7 +305,7 @@ RSpec.describe Asciidoctor::ISO do
          <terms id="_" obligation="normative">
          <title>Terms and definitions</title>
          #{TERM_BOILERPLATE}
-         <term id="_">
+         <term id="term-term1">
          <preferred>Term1</preferred>
          <termsource status="identical">
          <origin bibitemid="ISO2191" type="inline" citeas="">
@@ -753,7 +753,7 @@ RSpec.describe Asciidoctor::ISO do
   it "reorders references in bibliography, and renumbers citations accordingly" do
     expect(xmlpp(strip_guid(Asciidoctor.convert(<<~"INPUT", backend: :iso, header_footer: true)))).to be_equivalent_to xmlpp(<<~"OUTPUT")
     #{ASCIIDOC_BLANK_HDR}
-    
+
     == Clause 1
     <<ref1>>
     <<ref1a>>

--- a/spec/asciidoctor-iso/macros_spec.rb
+++ b/spec/asciidoctor-iso/macros_spec.rb
@@ -18,4 +18,260 @@ RSpec.describe Asciidoctor::ISO do
     OUTPUT
   end
 
+  describe 'term inline macros' do
+    subject(:convert) do
+      xmlpp(
+        strip_guid(
+          Asciidoctor.convert(
+            input, backend: :iso, header_footer: true)))
+    end
+    let(:input) do
+      <<~XML
+        #{ASCIIDOC_BLANK_HDR}
+        == Terms and Definitions
+
+        === name2
+
+        == Main
+
+        term:[name,name2]
+      XML
+    end
+    let(:output) do
+      <<~XML
+        #{BLANK_HDR}
+        <sections>
+          <terms id='_' obligation='normative'>
+            <title>Terms and definitions</title>
+            <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
+            <p id='_'>
+              ISO and IEC maintain terminological databases for use in standardization
+              at the following addresses:
+            </p>
+            <ul id='_'>
+              <li>
+                <p id='_'>
+                  ISO Online browsing platform: available at
+                  <link target='http://www.iso.org/obp'/>
+                </p>
+              </li>
+              <li>
+                <p id='_'>
+                  IEC Electropedia: available at
+                  <link target='http://www.electropedia.org'/>
+                </p>
+              </li>
+            </ul>
+            <term id='term-name2'>
+              <preferred>name2</preferred>
+            </term>
+          </terms>
+          <clause id='_' inline-header='false' obligation='normative'>
+            <title>Main</title>
+            <p id='_'>
+              <em>name</em>
+              (
+              <xref target='term-name2'/>
+              )
+            </p>
+          </clause>
+        </sections>
+        </iso-standard>
+      XML
+    end
+
+    it 'converts macro into the correct xml' do
+      expect(convert).to(be_equivalent_to(xmlpp(output)))
+    end
+
+    context 'default params' do
+      let(:input) do
+        <<~XML
+          #{ASCIIDOC_BLANK_HDR}
+
+          == Terms and Definitions
+
+          === name
+
+          == Main
+
+          term:[name]
+        XML
+      end
+      let(:output) do
+        <<~XML
+          #{BLANK_HDR}
+          <sections>
+            <terms id='_' obligation='normative'>
+              <title>Terms and definitions</title>
+              <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
+              <p id='_'>
+                ISO and IEC maintain terminological databases for use in standardization
+                at the following addresses:
+              </p>
+              <ul id='_'>
+                <li>
+                  <p id='_'>
+                    ISO Online browsing platform: available at
+                    <link target='http://www.iso.org/obp' />
+                  </p>
+                </li>
+                <li>
+                  <p id='_'>
+                    IEC Electropedia: available at
+                    <link target='http://www.electropedia.org' />
+                  </p>
+                </li>
+              </ul>
+              <term id='term-name'>
+                <preferred>name</preferred>
+              </term>
+            </terms>
+            <clause id='_' inline-header='false' obligation='normative'>
+              <title>Main</title>
+              <p id='_'>
+                <em>name</em>
+                (
+                <xref target='term-name'>name</xref>
+                )
+              </p>
+            </clause>
+          </sections>
+          </iso-standard>
+        XML
+      end
+
+      it 'uses `name` as termref name' do
+        expect(convert).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'multiply exising ids in document' do
+      let(:input) do
+        <<~XML
+          #{ASCIIDOC_BLANK_HDR}
+
+          == Terms and Definitions
+
+          === name
+          === name2
+
+          [[term-name]]
+          == Main
+
+          paragraph
+
+          [[term-name2]]
+          == Second
+
+          term:[name]
+          term:[name2]
+        XML
+      end
+      let(:output) do
+        <<~XML
+          #{BLANK_HDR}
+          <sections>
+            <terms id='_' obligation='normative'>
+              <title>Terms and definitions</title>
+              <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
+              <p id='_'>
+                ISO and IEC maintain terminological databases for use in standardization
+                at the following addresses:
+              </p>
+              <ul id='_'>
+                <li>
+                  <p id='_'>
+                    ISO Online browsing platform: available at
+                    <link target='http://www.iso.org/obp' />
+                  </p>
+                </li>
+                <li>
+                  <p id='_'>
+                    IEC Electropedia: available at
+                    <link target='http://www.electropedia.org' />
+                  </p>
+                </li>
+              </ul>
+              <term id='term-name-1'>
+                <preferred>name</preferred>
+              </term>
+              <term id='term-name2-1'>
+                <preferred>name2</preferred>
+              </term>
+            </terms>
+            <clause id='term-name' inline-header='false' obligation='normative'>
+              <title>Main</title>
+              <p id='_'>paragraph</p>
+            </clause>
+            <clause id='term-name2' inline-header='false' obligation='normative'>
+              <title>Second</title>
+              <p id='_'>
+                <em>name</em>
+                (
+                <xref target='term-name-1'>name</xref>
+                )
+                <em>name2</em>
+                  (
+                <xref target='term-name2-1'>name2</xref>
+                )
+              </p>
+            </clause>
+          </sections>
+          </iso-standard>
+        XML
+      end
+
+      it 'generates unique ids which dont match existing ids' do
+        expect(convert).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'using clause tags with id matcing `term-*`' do
+      let(:input) do
+        <<~XML
+          #{ASCIIDOC_BLANK_HDR}
+
+          [[terms-concepts]]
+          ==== Basic concepts
+
+          paragraph
+
+          [[term-date]]
+          ===== date
+
+          paragraph
+
+          term:[date]
+        XML
+      end
+
+      let(:output) do
+        <<~XML
+          #{BLANK_HDR}
+            <sections>
+              <clause id='terms-concepts' inline-header='false' obligation='normative'>
+                <title>Basic concepts</title>
+                <p id='_'>paragraph</p>
+                <clause id='term-date' inline-header='false' obligation='normative'>
+                  <title>date</title>
+                  <p id='_'>paragraph</p>
+                  <p id='_'>
+                    <em>date</em>
+                     (
+                    <xref target='term-date'>date</xref>
+                    )
+                  </p>
+                </clause>
+              </clause>
+            </sections>
+          </iso-standard>
+        XML
+      end
+
+      it 'generates unique ids which dont match existing ids' do
+        expect(convert).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+  end
 end

--- a/spec/asciidoctor-iso/macros_spec.rb
+++ b/spec/asciidoctor-iso/macros_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Asciidoctor::ISO do
             <p id='_'>
               <em>name</em>
               (
-              <xref target='term-name2'/>
+              <xref target='term-name2'>name2</xref>
               )
             </p>
           </clause>
@@ -132,7 +132,7 @@ RSpec.describe Asciidoctor::ISO do
               <p id='_'>
                 <em>name</em>
                 (
-                <xref target='term-name'>name</xref>
+                <xref target='term-name' />
                 )
               </p>
             </clause>
@@ -209,62 +209,15 @@ RSpec.describe Asciidoctor::ISO do
               <p id='_'>
                 <em>name</em>
                 (
-                <xref target='term-name-1'>name</xref>
+                <xref target='term-name-1' />
                 )
                 <em>name2</em>
                   (
-                <xref target='term-name2-1'>name2</xref>
+                <xref target='term-name2-1' />
                 )
               </p>
             </clause>
           </sections>
-          </iso-standard>
-        XML
-      end
-
-      it 'generates unique ids which dont match existing ids' do
-        expect(convert).to(be_equivalent_to(xmlpp(output)))
-      end
-    end
-
-    context 'using clause tags with id matcing `term-*`' do
-      let(:input) do
-        <<~XML
-          #{ASCIIDOC_BLANK_HDR}
-
-          [[terms-concepts]]
-          ==== Basic concepts
-
-          paragraph
-
-          [[term-date]]
-          ===== date
-
-          paragraph
-
-          term:[date]
-        XML
-      end
-
-      let(:output) do
-        <<~XML
-          #{BLANK_HDR}
-            <sections>
-              <clause id='terms-concepts' inline-header='false' obligation='normative'>
-                <title>Basic concepts</title>
-                <p id='_'>paragraph</p>
-                <clause id='term-date' inline-header='false' obligation='normative'>
-                  <title>date</title>
-                  <p id='_'>paragraph</p>
-                  <p id='_'>
-                    <em>date</em>
-                     (
-                    <xref target='term-date'>date</xref>
-                    )
-                  </p>
-                </clause>
-              </clause>
-            </sections>
           </iso-standard>
         XML
       end

--- a/spec/asciidoctor-iso/section_spec.rb
+++ b/spec/asciidoctor-iso/section_spec.rb
@@ -84,7 +84,7 @@ standardization at the following addresses:</p>
 <link target="http://www.electropedia.org"/>
 </p> </li> </ul>
 
-         <term id="_">
+         <term id="term-term1">
          <preferred>Term1</preferred>
        </term>
        </terms>
@@ -109,7 +109,7 @@ standardization at the following addresses:</p>
   </li>
 </ul>
          <title>Normal Terms</title>
-         <term id="_">
+         <term id="term-term2">
          <preferred>Term2</preferred>
        </term>
        </terms>
@@ -247,7 +247,7 @@ standardization at the following addresses:</p>
          <p id="_">Foreword</p>
        </foreword></preface><sections>
        <terms id="_" obligation="normative">
-          <title>Terms and definitions</title><p id="_">For the purposes of this document, the terms and definitions 
+          <title>Terms and definitions</title><p id="_">For the purposes of this document, the terms and definitions
   given in <eref bibitemid="iso1234"/> and <eref bibitemid="iso5678"/> and the following apply.</p>
   <p id="_">ISO and IEC maintain terminological databases for use in
 standardization at the following addresses:</p>
@@ -259,7 +259,7 @@ standardization at the following addresses:</p>
 <link target="http://www.electropedia.org"/>
 </p> </li> </ul>
 
-  <term id="_">
+  <term id="term-term1">
   <preferred>Term1</preferred>
 </term>
        </terms></sections>
@@ -296,13 +296,13 @@ standardization at the following addresses:</p>
               <ul id='_'>
                 <li>
                   <p id='_'>
-                    ISO Online browsing platform: available at 
+                    ISO Online browsing platform: available at
                     <link target='http://www.iso.org/obp'/>
                   </p>
                 </li>
                 <li>
                   <p id='_'>
-                    IEC Electropedia: available at 
+                    IEC Electropedia: available at
                     <link target='http://www.electropedia.org'/>
                   </p>
                 </li>


### PR DESCRIPTION
This is the same code as #255 + lower casing as implemented by @opoudjis . (I've reverted them from master)

This functionality is current broken:

Word:
<img width="631" alt="Screen Shot 2020-05-07 at 12 54 26 PM" src="https://user-images.githubusercontent.com/11865/81256045-e23b8380-9061-11ea-92b6-4e6315382f9d.png">

HTML:
![image](https://user-images.githubusercontent.com/11865/81256054-e8c9fb00-9061-11ea-9eab-a591825c53a1.png)

PDF:
![image](https://user-images.githubusercontent.com/11865/81256061-ebc4eb80-9061-11ea-92e4-07035cdb9ce5.png)

@w00lf please remember to test functionality on REAL DOCUMENTS when marking a PR ready to merge. As we remember from yaml2text, having specs do not necessarily demonstrate whether things work in real life.