### PR TITLE
FIX: term referencing showing `<termref>` tags in HTML and PDF when term not defined

### DIFF
--- a/lib/asciidoctor/iso/macros.rb
+++ b/lib/asciidoctor/iso/macros.rb
@@ -14,8 +14,7 @@ module Asciidoctor
 
       def process(_parent, _target, attrs)
         termref = attrs['termxref'] || attrs['name']
-        defaultref = attrs['termxref'].nil? ? ' defaultref' : ''
-        "<em>#{attrs['name']}</em> (<termxref#{defaultref}>#{termref}</termxref>)"
+        "<em>#{attrs['name']}</em> (<termxref>#{termref}</termxref>)"
       end
     end
   end

--- a/lib/asciidoctor/iso/term_lookup_cleanup.rb
+++ b/lib/asciidoctor/iso/term_lookup_cleanup.rb
@@ -41,7 +41,10 @@ module Asciidoctor
                 "#{target}" is not defined in document.).gsub(/\s+/, ' '))
         log.add('AsciiDoc Input', node, "#{target} does not refer to a real term")
         node.next.remove
+        term_name_node = node.previous.previous
+        term_name_node.remove
         node.previous.remove
+        node.add_previous_sibling(term_name_node.text)
         node.remove
       end
 

--- a/lib/asciidoctor/iso/term_lookup_cleanup.rb
+++ b/lib/asciidoctor/iso/term_lookup_cleanup.rb
@@ -37,9 +37,12 @@ module Asciidoctor
       end
 
       def remove_missing_ref(node, target)
-        warn(%Q(Error: Term reference in `term[#{target}]` missing: \
-                "#{target}" is not defined in document.).gsub(/\s+/, ' '))
-        log.add('AsciiDoc Input', node, "#{target} does not refer to a real term")
+        log.add('AsciiDoc Input',
+                node,
+                %(Error: Term reference in `term[#{target}]` missing: \
+                "#{target}" is not defined in document))
+        # Term ref have parentess around it - (ref),
+        # if no target remove parentes and render as text
         node.next.remove
         term_name_node = node.previous.previous
         term_name_node.remove

--- a/spec/asciidoctor-iso/macros_spec.rb
+++ b/spec/asciidoctor-iso/macros_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe Asciidoctor::ISO do
                        (
                       <xref target='term-name'/>
                       )
-                      <em>missing</em>
+                      missing
                     </p>
                   </definition>
                 </term>

--- a/spec/asciidoctor-iso/macros_spec.rb
+++ b/spec/asciidoctor-iso/macros_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Asciidoctor::ISO do
             <p id='_'>
               <em>name</em>
               (
-              <xref target='term-name2'>name2</xref>
+              <xref target='term-name2'/>
               )
             </p>
           </clause>
@@ -218,6 +218,70 @@ RSpec.describe Asciidoctor::ISO do
               </p>
             </clause>
           </sections>
+          </iso-standard>
+        XML
+      end
+
+      it 'generates unique ids which dont match existing ids' do
+        expect(convert).to(be_equivalent_to(xmlpp(output)))
+      end
+    end
+
+    context 'when missing actual ref' do
+      let(:input) do
+        <<~XML
+          #{ASCIIDOC_BLANK_HDR}
+
+          == Terms and Definitions
+
+          === name
+
+          paragraph
+
+          term:[name]
+          term:[missing]
+        XML
+      end
+      let(:output) do
+        <<~XML
+          #{BLANK_HDR}
+            <sections>
+              <terms id='_' obligation='normative'>
+                <title>Terms and definitions</title>
+                <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
+                <p id='_'>
+                  ISO and IEC maintain terminological databases for use in standardization
+                  at the following addresses:
+                </p>
+                <ul id='_'>
+                  <li>
+                    <p id='_'>
+                      ISO Online browsing platform: available at
+                      <link target='http://www.iso.org/obp'/>
+                    </p>
+                  </li>
+                  <li>
+                    <p id='_'>
+                      IEC Electropedia: available at
+                      <link target='http://www.electropedia.org'/>
+                    </p>
+                  </li>
+                </ul>
+                <term id='term-name'>
+                  <preferred>name</preferred>
+                  <definition>
+                    <p id='_'>paragraph</p>
+                    <p id='_'>
+                      <em>name</em>
+                       (
+                      <xref target='term-name'/>
+                      )
+                      <em>missing</em>
+                    </p>
+                  </definition>
+                </term>
+              </terms>
+            </sections>
           </iso-standard>
         XML
       end


### PR DESCRIPTION
metanorma/metanorma-iso#370: remove ref tag to the missing terms from the document, added a new warning.
![image](https://user-images.githubusercontent.com/1158036/81382576-48361280-9117-11ea-87a8-c29c87b1a043.png)
![image](https://user-images.githubusercontent.com/1158036/81382626-5d12a600-9117-11ea-9040-6659c174c48e.png)
