### PR TITLE
Remove `sassc` from gem runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 #gem "asciimath", git: "https://github.com/asciidoctor/asciimath"
-gem 'isodoc',
-    git: 'https://github.com/metanorma/isodoc.git',
-    branch: 'feature/sassc-gem-dependecey-removal',
-    ref: '963c80b0c0c4f223fb461d159fea5a9a2e46be3f'
+
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 #gem "asciimath", git: "https://github.com/asciidoctor/asciimath"
+gem 'isodoc',
+    git: 'https://github.com/metanorma/isodoc.git',
+    branch: 'feature/sassc-gem-dependecey-removal',
+    ref: '536191fb46f9334e749bb56579901d784b25b751'
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 gem 'isodoc',
     git: 'https://github.com/metanorma/isodoc.git',
     branch: 'feature/sassc-gem-dependecey-removal',
-    ref: '536191fb46f9334e749bb56579901d784b25b751'
+    ref: '963c80b0c0c4f223fb461d159fea5a9a2e46be3f'
 gemspec
 
 if File.exist? 'Gemfile.devel'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
+require 'isodoc/gem_tasks'
 
+IsoDoc::GemTasks.install
 RSpec::Core::RakeTask.new(:spec)
 
 task default: :spec

--- a/metanorma-iso.gemspec
+++ b/metanorma-iso.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_dependency "ruby-jing"
-  # spec.add_dependency "isodoc", "~> 1.1.0"
+  spec.add_dependency "isodoc", "~> 1.1.0"
   spec.add_dependency "metanorma-standoc", "~> 1.4.0"
   spec.add_dependency "tokenizer", "~> 0.3.0"
   spec.add_dependency "twitter_cldr"

--- a/metanorma-iso.gemspec
+++ b/metanorma-iso.gemspec
@@ -30,13 +30,14 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_dependency "ruby-jing"
-  spec.add_dependency "isodoc", "~> 1.1.0"
+  # spec.add_dependency "isodoc", "~> 1.1.0"
   spec.add_dependency "metanorma-standoc", "~> 1.4.0"
   spec.add_dependency "tokenizer", "~> 0.3.0"
   spec.add_dependency "twitter_cldr"
   spec.add_dependency "mn2sts", "~> 1.2.0"
 
   spec.add_development_dependency "byebug"
+  spec.add_development_dependency "sassc", "2.4.0"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
   spec.add_development_dependency "guard", "~> 2.14"
   spec.add_development_dependency "guard-rspec", "~> 4.7"


### PR DESCRIPTION
metanorma/metanorma#109 moved sassc gem to dev dependency, temporary added isodoc to Gemfile, added rake build script override.