### PR TITLE
xml sts error

### DIFF
--- a/metanorma-iso.gemspec
+++ b/metanorma-iso.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "isodoc", "~> 1.6.2"
   spec.add_dependency "metanorma-standoc", "~> 1.9.0"
-  spec.add_dependency "mn2sts", "~> 1.5.0"
+  spec.add_dependency "mn2sts", "~> 1.7.0"
   spec.add_dependency "ruby-jing"
   spec.add_dependency "tokenizer", "~> 0.3.0"
   spec.add_dependency "twitter_cldr"


### PR DESCRIPTION
mn2sts v1.7.0 is released with fix of:

> java -Xss5m -Xmx1024m -jar /tmp/packed-mn-20210507-3566-ucgnzi/mn2sts.jar --xml-file-in ./tests/iso.xml --xml-file-out ./tests/iso.sts.xml
>
> org.xml.sax.SAXParseException; /home/runner/work/metanorma-snap/metanorma-snap/./tests/iso.sts.xml is NOT valid reason:
>
> Error:  org.xml.sax.SAXParseException; systemId: file:/home/runner/work/metanorma-snap/metanorma-snap/./tests/iso.sts.xml; lineNumber: 28; columnNumber: 14; cvc-complex-type.2.4.a: Invalid content was found starting with element 'title'. One of '{copyright-statement, copyright-year, copyright-holder, "http://www.niso.org/schemas/ali/1.0/":free_to_read, license}' is expected.

See https://github.com/metanorma/mn2sts/issues/35

Let's use it?