### PR TITLE
update mnconvert dependency to avoid conflict on metanorma-cli

### DIFF
--- a/lib/isodoc/iso/isosts_convert.rb
+++ b/lib/isodoc/iso/isosts_convert.rb
@@ -22,8 +22,12 @@ module IsoDoc
             f.path
           end
         FileUtils.rm_rf dir
-        MnConvert.convert(input_fname, output_fname || "#{fname}.#{@suffix}",
-                          MnConvert::InputFormat::MN, { output_format: :iso })
+        MnConvert.convert(input_fname,
+                          {
+                            input_format: MnConvert::InputFormat::MN,
+                            output_file: output_fname || "#{fname}.#{@suffix}",
+                            output_format: :iso,
+                          })
       end
     end
   end

--- a/lib/isodoc/iso/sts_convert.rb
+++ b/lib/isodoc/iso/sts_convert.rb
@@ -19,8 +19,11 @@ module IsoDoc
             f.path
           end
         FileUtils.rm_rf dir
-        MnConvert.convert(in_fname, out_fname || "#{filename}.#{@suffix}",
-                          MnConvert::InputFormat::MN)
+        MnConvert.convert(in_fname,
+                          {
+                            input_format: MnConvert::InputFormat::MN,
+                            output_file: out_fname || "#{filename}.#{@suffix}",
+                          })
       end
     end
   end

--- a/metanorma-iso.gemspec
+++ b/metanorma-iso.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.add_dependency "metanorma-standoc", "~> 1.11.0"
-  spec.add_dependency "mnconvert", "~> 1.8.0"
+  spec.add_dependency "mnconvert", "~> 2.0"
   spec.add_dependency "ruby-jing"
   spec.add_dependency "tokenizer", "~> 0.3.0"
   spec.add_dependency "twitter_cldr"


### PR DESCRIPTION
 - metanorma/metanorma-cli#261

### Metanorma PR checklist

 - NO Breaking changes (list related PRs)
 - NO Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - NO External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - NO Gem with native library introduced

### Depends on PRs

 - https://github.com/metanorma/mnconvert-ruby/pull/2

### Related PRs

 - https://github.com/metanorma/mnconvert-ruby/pull/2
 - https://github.com/metanorma/metanorma-cli/pull/262