### PR TITLE
allow normative references as subclause of main clause, with correct …

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,1 @@
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/terms-boilerplate-2"

--- a/lib/metanorma/iso/cleanup.rb
+++ b/lib/metanorma/iso/cleanup.rb
@@ -15,6 +15,12 @@ module Metanorma
         "//annex//fn | //references[@normative = 'false']//fn | " \
         "//clause[.//references[@normative = 'false']]//fn".freeze
 
+      NORM_REF =
+        "//bibliography/references[@normative = 'true'][not(@hidden)] | " \
+        "//bibliography/clause[.//references[@normative = 'true']] | "\
+        "//sections//references[@normative = 'true'][not(@hidden)]"
+          .freeze
+
       def other_footnote_renumber(xmldoc)
         seen = {}
         i = 0

--- a/lib/metanorma/iso/cleanup.rb
+++ b/lib/metanorma/iso/cleanup.rb
@@ -42,9 +42,9 @@ module Metanorma
       end
 
       TERM_CLAUSE =
-        "//sections//terms | " \
-        "//sections//clause[descendant::terms][not(descendant::definitions)]"
-          .freeze
+        "//sections//terms[not(.//ancestor::clause[@type = 'terms'])] | " \
+        "//sections//clause[descendant::terms][not(descendant::definitions)][@type = 'terms'] | " \
+        "//sections/clause[not(@type = 'terms')]//terms".freeze
 
       def sections_cleanup(xml)
         super

--- a/lib/metanorma/iso/cleanup.rb
+++ b/lib/metanorma/iso/cleanup.rb
@@ -42,9 +42,9 @@ module Metanorma
       end
 
       TERM_CLAUSE =
-        "//sections//terms[not(.//ancestor::clause[@type = 'terms'])] | " \
+        "//sections//terms[not(preceding-sibling::clause)] | " \
         "//sections//clause[descendant::terms][not(descendant::definitions)][@type = 'terms'] | " \
-        "//sections/clause[not(@type = 'terms')]//terms".freeze
+        "//sections/clause[not(@type = 'terms')][not(descendant::definitions)]//terms".freeze
 
       def sections_cleanup(xml)
         super
@@ -139,7 +139,7 @@ module Metanorma
         end
       end
 
-      def termdef_boilerplate_insert_location(xmldoc)
+      def termdef_boilerplate_insert_locationx(xmldoc)
         f = xmldoc.at(self.class::TERM_CLAUSE)
         root = xmldoc.at("//sections/terms | //sections/clause[.//terms]")
         !f || !root and return f || root

--- a/spec/metanorma/cleanup_spec.rb
+++ b/spec/metanorma/cleanup_spec.rb
@@ -1165,7 +1165,7 @@ RSpec.describe Metanorma::ISO do
       output = <<~OUTPUT
         #{BLANK_HDR}
           <sections>
-            <clause id='_' obligation='normative'>
+            <clause id='_' obligation='normative' type="terms">
               <title>Terms and definitions</title>
               <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
               <p id='_'>
@@ -1227,9 +1227,9 @@ RSpec.describe Metanorma::ISO do
       output = <<~OUTPUT
         #{BLANK_HDR}
           <sections>
-            <clause id='_' obligation='normative'>
+            <clause id='_' obligation='normative' type="terms">
               <title>Terms, definitions, symbols and abbreviated terms</title>
-              <clause id='_' obligation='normative'>
+              <clause id='_' obligation='normative' type="terms">
                 <title>Terms and definitions</title>
                 <p id='_'>For the purposes of this document, the following terms and definitions apply.</p>
                 <p id='_'>
@@ -1294,7 +1294,7 @@ RSpec.describe Metanorma::ISO do
       output = <<~OUTPUT
         #{BLANK_HDR}
           <sections>
-            <clause id='_' obligation='normative'>
+            <clause id='_' obligation='normative' type="terms">
               <title>Terms, definitions, symbols and abbreviated terms</title>
               <terms id='_' obligation='normative'>
                 <title>Terms and definitions</title>
@@ -1359,53 +1359,130 @@ RSpec.describe Metanorma::ISO do
         === Symbols and abbreviated terms
       INPUT
       output = <<~OUTPUT
-       #{BLANK_HDR}
+        #{BLANK_HDR}
+         <sections>
+            <clause id="_" obligation="normative" type="terms">
+              <title>Terms, definitions, symbols and abbreviated terms</title>
+                <p id="_">For the purposes of this document,
+            the following terms and definitions apply.</p>
+                <p id="_">ISO and IEC maintain terminology databases for use in
+        standardization at the following addresses:</p>
+                <ul id="_">
+                  <li>
+                    <p id="_">ISO Online browsing platform: available at
+          <link target="https://www.iso.org/obp"/></p>
+                  </li>
+                  <li>
+                    <p id="_">IEC Electropedia: available at
+        <link target="https://www.electropedia.org"/></p>
+                  </li>
+                </ul>
+                <clause id="_" inline-header="false" obligation="normative">
+                  <title>Prefatory clause</title>
+                </clause>
+              <terms id="_" obligation="normative">
+                <title>Terms and definitions</title>
+                <term id="term-Term1">
+                  <preferred>
+                    <expression>
+                      <name>Term1</name>
+                    </expression>
+                  </preferred>
+                </term>
+              </terms>
+              <terms id="_" obligation="normative">
+                <title>Other Terms</title>
+                <term id="term-Term-2">
+                  <preferred>
+                    <expression>
+                      <name>Term 2</name>
+                    </expression>
+                  </preferred>
+                </term>
+              </terms>
+              <definitions id="_" obligation="normative">
+                <title>Symbols and abbreviated terms</title>
+              </definitions>
+            </clause>
+          </sections>
+        </iso-standard>
+      OUTPUT
+      expect(xmlpp(strip_guid(Asciidoctor.convert(input, *OPTIONS))))
+        .to be_equivalent_to xmlpp(output)
+    end
+
+    it "places boilerplate in Normative References subclause" do
+      input = <<~INPUT
+        #{ASCIIDOC_BLANK_HDR}
+
+        [type=section]
+        == General
+
+        [heading=scope]
+        === Scope
+
+        This part of ISO 7005 for a single of flanges
+
+        [bibliography,heading=normative references]
+        === Normative references
+      INPUT
+      output = <<~OUTPUT
+        #{BLANK_HDR}
         <sections>
-           <clause id="_" obligation="normative">
-             <title>Terms, definitions, symbols and abbreviated terms</title>
-               <p id="_">For the purposes of this document,
-           the following terms and definitions apply.</p>
-               <p id="_">ISO and IEC maintain terminology databases for use in
-       standardization at the following addresses:</p>
-               <ul id="_">
-                 <li>
-                   <p id="_">ISO Online browsing platform: available at
-         <link target="https://www.iso.org/obp"/></p>
-                 </li>
-                 <li>
-                   <p id="_">IEC Electropedia: available at
-       <link target="https://www.electropedia.org"/></p>
-                 </li>
-               </ul>
-               <clause id="_" inline-header="false" obligation="normative">
-                 <title>Prefatory clause</title>
-               </clause>
-             <terms id="_" obligation="normative">
-               <title>Terms and definitions</title>
-               <term id="term-Term1">
-                 <preferred>
-                   <expression>
-                     <name>Term1</name>
-                   </expression>
-                 </preferred>
-               </term>
-             </terms>
-             <terms id="_" obligation="normative">
-               <title>Other Terms</title>
-               <term id="term-Term-2">
-                 <preferred>
-                   <expression>
-                     <name>Term 2</name>
-                   </expression>
-                 </preferred>
-               </term>
-             </terms>
-             <definitions id="_" obligation="normative">
-               <title>Symbols and abbreviated terms</title>
-             </definitions>
-           </clause>
-         </sections>
-       </iso-standard>
+            <clause id="_" type="section" inline-header="false" obligation="normative">
+              <title>General</title>
+              <clause id="_" type="scope" inline-header="false" obligation="normative">
+                <title>Scope</title>
+                <p id="_">This part of ISO 7005 for a single of flanges</p>
+              </clause>
+              <references id="_" normative="true" obligation="informative">
+                <title>Normative references</title>
+                <p id="_">There are no normative references in this document.</p>
+              </references>
+            </clause>
+          </sections>
+        </iso-standard>
+      OUTPUT
+      expect(xmlpp(strip_guid(Asciidoctor.convert(input, *OPTIONS))))
+        .to be_equivalent_to xmlpp(output)
+    end
+
+    it "places user-defined boilerplate in Normative References subclause" do
+      input = <<~INPUT
+        #{ASCIIDOC_BLANK_HDR}
+
+        [type=section]
+        == General
+
+        [heading=scope]
+        === Scope
+
+        This part of ISO 7005 for a single of flanges
+
+        [bibliography,heading=normative references]
+        === Normative references
+
+        [.boilerplate]
+        --
+        The following standards contain provisions
+        --
+      INPUT
+      output = <<~OUTPUT
+        #{BLANK_HDR}
+        <sections>
+            <clause id="_" type="section" inline-header="false" obligation="normative">
+              <title>General</title>
+              <clause id="_" type="scope" inline-header="false" obligation="normative">
+                <title>Scope</title>
+                <p id="_">This part of ISO 7005 for a single of flanges</p>
+              </clause>
+              <references id="_" normative="true" obligation="informative">
+                <title>Normative references</title>
+                <p id="_">The following standards contain provisions</p>
+              </references>
+            </clause>
+          </sections>
+        </iso-standard>
       OUTPUT
       expect(xmlpp(strip_guid(Asciidoctor.convert(input, *OPTIONS))))
         .to be_equivalent_to xmlpp(output)

--- a/spec/metanorma/section_spec.rb
+++ b/spec/metanorma/section_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Metanorma::ISO do
             <title>Scope</title>
             <p id="_">Text</p>
           </clause>
-          <clause id="_" obligation="normative">
+          <clause id="_" obligation="normative" type="terms">
             <title>Terms, definitions, symbols and abbreviated terms</title>
                          <terms id="_" obligation="normative">
                <title>Terms and definitions</title>


### PR DESCRIPTION
…boilerplate placement: https://github.com/metanorma/metanorma-iso/issues/1167

### Metanorma PR checklist

 - [x] Breaking changes (list related PRs) : https://github.com/metanorma/metanorma-standoc/pull/889
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to imporove/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
