### PR TITLE
remove '(all parts)' from citations, leaving it only in references; d…

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,3 +1,2 @@
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "fix/all_parts_citations"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
-em "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/redundant-space-before-lines-run"

--- a/lib/isodoc/iso/init.rb
+++ b/lib/isodoc/iso/init.rb
@@ -63,7 +63,8 @@ module IsoDoc
       end
 
       def std_docid_semantic1(id)
-        ids = id.split(/(\p{Zs})/)
+        id1 = id.sub(%r{\p{Zs}\(all\p{Zs}parts\)}, "###ALLPARTS###")
+        ids = id1.split(/(\p{Zs})/)
         agency?(ids[0].sub(%r{^([^/]+)/.*$}, "\\1")) or return id
         ids.map! do |i|
           if %w(GUIDE TR TS DIR).include?(i)
@@ -72,6 +73,7 @@ module IsoDoc
           else std_docid_semantic_full(i)
           end
         end.join.gsub(%r{</span>(\p{Zs}+)<}, "\\1</span><")
+          .sub("###ALLPARTS###", " (all parts)")
       end
 
       def std_docid_semantic_full(ident)

--- a/lib/isodoc/iso/presentation_terms.rb
+++ b/lib/isodoc/iso/presentation_terms.rb
@@ -12,8 +12,8 @@ module IsoDoc
         (docxml.xpath(ns("//concept")) - docxml.xpath(ns("//term//concept")))
           .each do |node|
           node.ancestors("definition, termsource, related").empty? and
-          concept_render(node, ital: "false", ref: "false",
-                               linkref: "true", linkmention: "false")
+            concept_render(node, ital: "false", ref: "false",
+                                 linkref: "true", linkmention: "false")
         end
       end
 
@@ -23,7 +23,7 @@ module IsoDoc
           (f.xpath(ns(".//concept")) - f.xpath(ns(".//term//concept")))
             .each do |c|
               c.ancestors("definition, termsource, related").empty? and
-              concept_term1(c, m)
+                concept_term1(c, m)
             end
         end
       end

--- a/spec/isodoc/blocks_spec.rb
+++ b/spec/isodoc/blocks_spec.rb
@@ -1656,8 +1656,7 @@ RSpec.describe IsoDoc do
                         </fmt-xref>
                      </semx>
                      &#x2014;
-                     <semx element="modification" source="_">with adjustments</semx>
-                     ;
+                     with adjustments;
                      <origin bibitemid="ISO712" type="inline" citeas="ISO 712" id="_">
                         <localityStack>
                            <locality type="section">

--- a/spec/isodoc/concept_spec.rb
+++ b/spec/isodoc/concept_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe IsoDoc do
           </iso-standard>
     INPUT
     presxml = <<~OUTPUT
-     <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
+       <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
           <preface>
              <clause type="toc" id="_" displayorder="1">
                 <fmt-title depth="1">Contents</fmt-title>
@@ -155,7 +155,7 @@ RSpec.describe IsoDoc do
                             </fmt-name>
                             <concept id="_">
                                <refterm>term0</refterm>
-                               <xref target="clause1" original-id="_"/>
+                               <xref target="clause1" id="_"/>
                             </concept>
                             <fmt-concept>
                                <semx element="concept" source="_">
@@ -179,7 +179,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term1</refterm>
                                <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
+                               <xref target="clause1" id="_"/>
                             </concept>
                             <fmt-concept>
                                <semx element="concept" source="_">
@@ -204,7 +204,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term2</refterm>
                                <renderterm>w[o]rd</renderterm>
-                               <xref target="clause1" original-id="_">Clause #1</xref>
+                               <xref target="clause1" id="_">Clause #1</xref>
                             </concept>
                             <fmt-concept>
                                <semx element="concept" source="_">
@@ -224,7 +224,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term3</refterm>
                                <renderterm>term</renderterm>
-                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" original-id="_"/>
+                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" id="_"/>
                             </concept>
                             <fmt-concept>
                                <semx element="concept" source="_">
@@ -247,7 +247,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term4</refterm>
                                <renderterm>word</renderterm>
-                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" original-id="_">The Aforementioned Citation</eref>
+                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" id="_">The Aforementioned Citation</eref>
                             </concept>
                             <fmt-concept>
                                <semx element="concept" source="_">
@@ -267,7 +267,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term5</refterm>
                                <renderterm>word</renderterm>
-                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" original-id="_">
+                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" id="_">
                                   <locality type="clause">
                                      <referenceFrom>3.1</referenceFrom>
                                   </locality>
@@ -301,7 +301,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term6</refterm>
                                <renderterm>word</renderterm>
-                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" original-id="_">
+                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" id="_">
                                   <localityStack connective="and">
                                      <locality type="clause">
                                         <referenceFrom>3.1</referenceFrom>
@@ -339,7 +339,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term7</refterm>
                                <renderterm>word</renderterm>
-                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" original-id="_">
+                               <eref bibitemid="ISO712" type="inline" citeas="ISO 712" id="_">
                                   <localityStack connective="and">
                                      <locality type="clause">
                                         <referenceFrom>3.1</referenceFrom>
@@ -663,7 +663,7 @@ RSpec.describe IsoDoc do
                       <concept id="_">
                          <refterm>term1</refterm>
                          <renderterm>term</renderterm>
-                         <xref target="clause1" original-id="_"/>
+                         <xref target="clause1" id="_"/>
                       </concept>
                       <fmt-concept>
                          <semx element="concept" source="_">term</semx>
@@ -704,7 +704,7 @@ RSpec.describe IsoDoc do
                          <concept id="_">
                             <refterm>term1</refterm>
                             <renderterm>term</renderterm>
-                            <xref target="clause1" original-id="_"/>
+                            <xref target="clause1" id="_"/>
                          </concept>
                          <fmt-concept>
                             <semx element="concept" source="_">term</semx>
@@ -733,7 +733,7 @@ RSpec.describe IsoDoc do
                          <concept id="_">
                             <refterm>term1</refterm>
                             <renderterm>term</renderterm>
-                            <xref target="clause1" original-id="_"/>
+                            <xref target="clause1" id="_"/>
                          </concept>
                          <fmt-concept>
                             <semx element="concept" source="_">
@@ -759,7 +759,7 @@ RSpec.describe IsoDoc do
                          <concept id="_">
                             <refterm>term1</refterm>
                             <renderterm>term</renderterm>
-                            <xref target="clause1" original-id="_"/>
+                            <xref target="clause1" id="_"/>
                          </concept>
                          <fmt-concept>
                             <semx element="concept" source="_">term</semx>
@@ -788,7 +788,7 @@ RSpec.describe IsoDoc do
                          <concept id="_">
                             <refterm>term1</refterm>
                             <renderterm>term</renderterm>
-                            <xref target="clause1" original-id="_"/>
+                            <xref target="clause1" id="_"/>
                          </concept>
                          <fmt-concept>
                             <semx element="concept" source="_">
@@ -814,7 +814,7 @@ RSpec.describe IsoDoc do
                          <concept id="_">
                             <refterm>term1</refterm>
                             <renderterm>term</renderterm>
-                            <xref target="clause1" original-id="_"/>
+                            <xref target="clause1" id="_"/>
                          </concept>
                          <fmt-concept>
                             <semx element="concept" source="_">term</semx>
@@ -843,7 +843,7 @@ RSpec.describe IsoDoc do
                          <concept id="_">
                             <refterm>term1</refterm>
                             <renderterm>term</renderterm>
-                            <xref target="clause1" original-id="_"/>
+                            <xref target="clause1" id="_"/>
                          </concept>
                          <fmt-concept>
                             <semx element="concept" source="_">
@@ -869,7 +869,7 @@ RSpec.describe IsoDoc do
                          <concept id="_">
                             <refterm>term1</refterm>
                             <renderterm>term</renderterm>
-                            <xref target="clause1" original-id="_"/>
+                            <xref target="clause1" id="_"/>
                          </concept>
                          <fmt-concept>
                             <semx element="concept" source="_">term</semx>
@@ -901,7 +901,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term1</refterm>
                                <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
+                               <xref target="clause1" id="_"/>
                             </concept>
                             <fmt-concept>
                                <semx element="concept" source="_">
@@ -927,7 +927,7 @@ RSpec.describe IsoDoc do
                             <concept id="_">
                                <refterm>term1</refterm>
                                <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
+                               <xref target="clause1" id="_"/>
                             </concept>
                             <fmt-concept>
                                <semx element="concept" source="_">term</semx>
@@ -969,97 +969,97 @@ RSpec.describe IsoDoc do
       </terms>
       </sections>
       </iso-standard>
-      INPUT
-      presxml = <<~OUTPUT
-        <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
-           <preface>
-              <clause type="toc" id="_" displayorder="1">
-                 <fmt-title depth="1">Contents</fmt-title>
-              </clause>
-           </preface>
-           <sections>
-              <terms id="Terms" displayorder="2">
-                 <fmt-title depth="1">
-                    <span class="fmt-caption-label">
-                       <semx element="autonum" source="Terms">1</semx>
-                    </span>
-                 </fmt-title>
-                 <fmt-xref-label>
-                    <span class="fmt-element-name">Clause</span>
-                    <semx element="autonum" source="Terms">1</semx>
-                 </fmt-xref-label>
-                 <term id="clause1">
-                    <fmt-name>
-                       <span class="fmt-caption-label">
-                          <semx element="autonum" source="Terms">1</semx>
-                          <span class="fmt-autonum-delim">.</span>
-                          <semx element="autonum" source="clause1">1</semx>
-                       </span>
-                    </fmt-name>
-                    <fmt-xref-label>
-                       <semx element="autonum" source="Terms">1</semx>
-                       <span class="fmt-autonum-delim">.</span>
-                       <semx element="autonum" source="clause1">1</semx>
-                    </fmt-xref-label>
-                    <preferred id="_">A</preferred>
-                    <definition id="_">
-                       <ul>
-                          <concept>
-                             <refterm>term1</refterm>
-                             <renderterm>term</renderterm>
-                             <xref target="clause1"/>
-                          </concept>
-                       </ul>
-                       <li>
-                          <concept>
-                             <refterm>term1</refterm>
-                             <renderterm>term</renderterm>
-                             <xref target="clause1"/>
-                          </concept>
-                       </li>
-                    </definition>
-                    <fmt-definition>
-                       <semx element="definition" source="_">
-                          <ul>
-                             <concept id="_">
-                                <refterm>term1</refterm>
-                                <renderterm>term</renderterm>
-                                <xref target="clause1" original-id="_"/>
-                             </concept>
-                             <fmt-concept>
-                                <semx element="concept" source="_">
-                                   <em>term</em>
-                                   <semx element="xref" source="_">
-                                      (
-                                      <fmt-xref target="clause1">
-                                         <span class="citesec">
-                                            <semx element="autonum" source="Terms">1</semx>
-                                            <span class="fmt-autonum-delim">.</span>
-                                            <semx element="autonum" source="clause1">1</semx>
-                                         </span>
-                                      </fmt-xref>
-                                      )
-                                   </semx>
-                                </semx>
-                             </fmt-concept>
-                          </ul>
-                          <li>
-                             <concept id="_">
-                                <refterm>term1</refterm>
-                                <renderterm>term</renderterm>
-                                <xref target="clause1" original-id="_"/>
-                             </concept>
-                             <fmt-concept>
-                                <semx element="concept" source="_">term</semx>
-                             </fmt-concept>
-                          </li>
-                       </semx>
-                    </fmt-definition>
-                 </term>
-              </terms>
-           </sections>
-        </iso-standard>
-        OUTPUT
+    INPUT
+    presxml = <<~OUTPUT
+      <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
+         <preface>
+            <clause type="toc" id="_" displayorder="1">
+               <fmt-title depth="1">Contents</fmt-title>
+            </clause>
+         </preface>
+         <sections>
+            <terms id="Terms" displayorder="2">
+               <fmt-title depth="1">
+                  <span class="fmt-caption-label">
+                     <semx element="autonum" source="Terms">1</semx>
+                  </span>
+               </fmt-title>
+               <fmt-xref-label>
+                  <span class="fmt-element-name">Clause</span>
+                  <semx element="autonum" source="Terms">1</semx>
+               </fmt-xref-label>
+               <term id="clause1">
+                  <fmt-name>
+                     <span class="fmt-caption-label">
+                        <semx element="autonum" source="Terms">1</semx>
+                        <span class="fmt-autonum-delim">.</span>
+                        <semx element="autonum" source="clause1">1</semx>
+                     </span>
+                  </fmt-name>
+                  <fmt-xref-label>
+                     <semx element="autonum" source="Terms">1</semx>
+                     <span class="fmt-autonum-delim">.</span>
+                     <semx element="autonum" source="clause1">1</semx>
+                  </fmt-xref-label>
+                  <preferred id="_">A</preferred>
+                  <definition id="_">
+                     <ul>
+                        <concept>
+                           <refterm>term1</refterm>
+                           <renderterm>term</renderterm>
+                           <xref target="clause1"/>
+                        </concept>
+                     </ul>
+                     <li>
+                        <concept>
+                           <refterm>term1</refterm>
+                           <renderterm>term</renderterm>
+                           <xref target="clause1"/>
+                        </concept>
+                     </li>
+                  </definition>
+                  <fmt-definition>
+                     <semx element="definition" source="_">
+                        <ul>
+                           <concept id="_">
+                              <refterm>term1</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">
+                                 <em>term</em>
+                                 <semx element="xref" source="_">
+                                    (
+                                    <fmt-xref target="clause1">
+                                       <span class="citesec">
+                                          <semx element="autonum" source="Terms">1</semx>
+                                          <span class="fmt-autonum-delim">.</span>
+                                          <semx element="autonum" source="clause1">1</semx>
+                                       </span>
+                                    </fmt-xref>
+                                    )
+                                 </semx>
+                              </semx>
+                           </fmt-concept>
+                        </ul>
+                        <li>
+                           <concept id="_">
+                              <refterm>term1</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">term</semx>
+                           </fmt-concept>
+                        </li>
+                     </semx>
+                  </fmt-definition>
+               </term>
+            </terms>
+         </sections>
+      </iso-standard>
+    OUTPUT
     expect(Xml::C14n.format(strip_guid(IsoDoc::Iso::PresentationXMLConvert
       .new(presxml_options)
        .convert("test", input, true))))
@@ -1111,290 +1111,290 @@ RSpec.describe IsoDoc do
       </iso-standard>
     INPUT
     presxml = <<~OUTPUT
-       <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
-          <preface>
-             <clause type="toc" id="_" displayorder="1">
-                <fmt-title depth="1">Contents</fmt-title>
-             </clause>
-          </preface>
-          <sections>
-             <clause id="clause1" displayorder="2">
-                <title id="_">Clause 1</title>
-                <fmt-title depth="1">
-                   <span class="fmt-caption-label">
-                      <semx element="autonum" source="clause1">1</semx>
-                   </span>
-                   <span class="fmt-caption-delim">
-                      <tab/>
-                   </span>
-                   <semx element="title" source="_">Clause 1</semx>
-                </fmt-title>
-                <fmt-xref-label>
-                   <span class="fmt-element-name">Clause</span>
-                   <semx element="autonum" source="clause1">1</semx>
-                </fmt-xref-label>
-             </clause>
-             <terms id="A" displayorder="3">
-                <fmt-title depth="1">
-                   <span class="fmt-caption-label">
-                      <semx element="autonum" source="A">2</semx>
-                   </span>
-                </fmt-title>
-                <fmt-xref-label>
-                   <span class="fmt-element-name">Clause</span>
-                   <semx element="autonum" source="A">2</semx>
-                </fmt-xref-label>
-                <term id="B">
-                   <fmt-name>
-                      <span class="fmt-caption-label">
-                         <semx element="autonum" source="A">2</semx>
-                         <span class="fmt-autonum-delim">.</span>
-                         <semx element="autonum" source="B">1</semx>
-                      </span>
-                   </fmt-name>
-                   <fmt-xref-label>
-                      <semx element="autonum" source="A">2</semx>
-                      <span class="fmt-autonum-delim">.</span>
-                      <semx element="autonum" source="B">1</semx>
-                   </fmt-xref-label>
-                   <preferred id="_">
-                      <expression>
-                         <name>B</name>
-                      </expression>
-                   </preferred>
-                   <fmt-preferred>
-                      <p>
-                         <semx element="preferred" source="_">
-                            <strong>B</strong>
-                         </semx>
-                      </p>
-                   </fmt-preferred>
-                   <p>
-                      <ul>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ital="true" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">
-                                  <em>term</em>
-                                  <semx element="xref" source="_">
-                                     (
-                                     <fmt-xref target="clause1">
-                                        <span class="citesec">
-                                           <span class="fmt-element-name">Clause</span>
-                                           <semx element="autonum" source="clause1">1</semx>
-                                        </span>
-                                     </fmt-xref>
-                                     )
-                                  </semx>
-                               </semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ref="true" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">
-                                  term
-                                  <semx element="xref" source="_">
-                                     (
-                                     <fmt-xref target="clause1">
-                                        <span class="citesec">
-                                           <span class="fmt-element-name">Clause</span>
-                                           <semx element="autonum" source="clause1">1</semx>
-                                        </span>
-                                     </fmt-xref>
-                                     )
-                                  </semx>
-                               </semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ital="true" ref="true" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">
-                                  <em>term</em>
-                                  <semx element="xref" source="_">
-                                     (
-                                     <fmt-xref target="clause1">
-                                        <span class="citesec">
-                                           <span class="fmt-element-name">Clause</span>
-                                           <semx element="autonum" source="clause1">1</semx>
-                                        </span>
-                                     </fmt-xref>
-                                     )
-                                  </semx>
-                               </semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ital="false" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">term</semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ref="false" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">term</semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ital="false" ref="false" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">term</semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ital="true" ref="true" linkmention="true" linkref="true" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">
-                                  <semx element="xref" source="_">
-                                     <fmt-xref target="clause1">
-                                        <em>term</em>
-                                     </fmt-xref>
-                                  </semx>
-                                  <semx element="xref" source="_">
-                                     (
-                                     <fmt-xref target="clause1">
-                                        <span class="citesec">
-                                           <span class="fmt-element-name">Clause</span>
-                                           <semx element="autonum" source="clause1">1</semx>
-                                        </span>
-                                     </fmt-xref>
-                                     )
-                                  </semx>
-                               </semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ital="true" ref="true" linkmention="true" linkref="false" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">
-                                  <semx element="xref" source="_">
-                                     <fmt-xref target="clause1">
-                                        <em>term</em>
-                                     </fmt-xref>
-                                  </semx>
-                                  <semx element="xref" source="_">
-                                     (
-                                     <span class="citesec">
-                                        <span class="fmt-element-name">Clause</span>
-                                        <semx element="autonum" source="clause1">1</semx>
-                                     </span>
-                                     )
-                                  </semx>
-                               </semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ital="true" ref="true" linkmention="false" linkref="true" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">
-                                  <em>term</em>
-                                  <semx element="xref" source="_">
-                                     (
-                                     <fmt-xref target="clause1">
-                                        <span class="citesec">
-                                           <span class="fmt-element-name">Clause</span>
-                                           <semx element="autonum" source="clause1">1</semx>
-                                        </span>
-                                     </fmt-xref>
-                                     )
-                                  </semx>
-                               </semx>
-                            </fmt-concept>
-                         </li>
-                         <li>
-                            <fmt-name>
-                               <semx element="autonum" source="">—</semx>
-                            </fmt-name>
-                            <concept ital="true" ref="true" linkmention="false" linkref="false" id="_">
-                               <refterm>term</refterm>
-                               <renderterm>term</renderterm>
-                               <xref target="clause1" original-id="_"/>
-                            </concept>
-                            <fmt-concept>
-                               <semx element="concept" source="_">
-                                  <em>term</em>
-                                  <semx element="xref" source="_">
-                                     (
-                                     <span class="citesec">
-                                        <span class="fmt-element-name">Clause</span>
-                                        <semx element="autonum" source="clause1">1</semx>
-                                     </span>
-                                     )
-                                  </semx>
-                               </semx>
-                            </fmt-concept>
-                         </li>
-                      </ul>
-                   </p>
-                </term>
-             </terms>
-          </sections>
-       </iso-standard>
+      <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
+         <preface>
+            <clause type="toc" id="_" displayorder="1">
+               <fmt-title depth="1">Contents</fmt-title>
+            </clause>
+         </preface>
+         <sections>
+            <clause id="clause1" displayorder="2">
+               <title id="_">Clause 1</title>
+               <fmt-title depth="1">
+                  <span class="fmt-caption-label">
+                     <semx element="autonum" source="clause1">1</semx>
+                  </span>
+                  <span class="fmt-caption-delim">
+                     <tab/>
+                  </span>
+                  <semx element="title" source="_">Clause 1</semx>
+               </fmt-title>
+               <fmt-xref-label>
+                  <span class="fmt-element-name">Clause</span>
+                  <semx element="autonum" source="clause1">1</semx>
+               </fmt-xref-label>
+            </clause>
+            <terms id="A" displayorder="3">
+               <fmt-title depth="1">
+                  <span class="fmt-caption-label">
+                     <semx element="autonum" source="A">2</semx>
+                  </span>
+               </fmt-title>
+               <fmt-xref-label>
+                  <span class="fmt-element-name">Clause</span>
+                  <semx element="autonum" source="A">2</semx>
+               </fmt-xref-label>
+               <term id="B">
+                  <fmt-name>
+                     <span class="fmt-caption-label">
+                        <semx element="autonum" source="A">2</semx>
+                        <span class="fmt-autonum-delim">.</span>
+                        <semx element="autonum" source="B">1</semx>
+                     </span>
+                  </fmt-name>
+                  <fmt-xref-label>
+                     <semx element="autonum" source="A">2</semx>
+                     <span class="fmt-autonum-delim">.</span>
+                     <semx element="autonum" source="B">1</semx>
+                  </fmt-xref-label>
+                  <preferred id="_">
+                     <expression>
+                        <name>B</name>
+                     </expression>
+                  </preferred>
+                  <fmt-preferred>
+                     <p>
+                        <semx element="preferred" source="_">
+                           <strong>B</strong>
+                        </semx>
+                     </p>
+                  </fmt-preferred>
+                  <p>
+                     <ul>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ital="true" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">
+                                 <em>term</em>
+                                 <semx element="xref" source="_">
+                                    (
+                                    <fmt-xref target="clause1">
+                                       <span class="citesec">
+                                          <span class="fmt-element-name">Clause</span>
+                                          <semx element="autonum" source="clause1">1</semx>
+                                       </span>
+                                    </fmt-xref>
+                                    )
+                                 </semx>
+                              </semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ref="true" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">
+                                 term
+                                 <semx element="xref" source="_">
+                                    (
+                                    <fmt-xref target="clause1">
+                                       <span class="citesec">
+                                          <span class="fmt-element-name">Clause</span>
+                                          <semx element="autonum" source="clause1">1</semx>
+                                       </span>
+                                    </fmt-xref>
+                                    )
+                                 </semx>
+                              </semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ital="true" ref="true" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">
+                                 <em>term</em>
+                                 <semx element="xref" source="_">
+                                    (
+                                    <fmt-xref target="clause1">
+                                       <span class="citesec">
+                                          <span class="fmt-element-name">Clause</span>
+                                          <semx element="autonum" source="clause1">1</semx>
+                                       </span>
+                                    </fmt-xref>
+                                    )
+                                 </semx>
+                              </semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ital="false" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">term</semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ref="false" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">term</semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ital="false" ref="false" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">term</semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ital="true" ref="true" linkmention="true" linkref="true" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">
+                                 <semx element="xref" source="_">
+                                    <fmt-xref target="clause1">
+                                       <em>term</em>
+                                    </fmt-xref>
+                                 </semx>
+                                 <semx element="xref" source="_">
+                                    (
+                                    <fmt-xref target="clause1">
+                                       <span class="citesec">
+                                          <span class="fmt-element-name">Clause</span>
+                                          <semx element="autonum" source="clause1">1</semx>
+                                       </span>
+                                    </fmt-xref>
+                                    )
+                                 </semx>
+                              </semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ital="true" ref="true" linkmention="true" linkref="false" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">
+                                 <semx element="xref" source="_">
+                                    <fmt-xref target="clause1">
+                                       <em>term</em>
+                                    </fmt-xref>
+                                 </semx>
+                                 <semx element="xref" source="_">
+                                    (
+                                    <span class="citesec">
+                                       <span class="fmt-element-name">Clause</span>
+                                       <semx element="autonum" source="clause1">1</semx>
+                                    </span>
+                                    )
+                                 </semx>
+                              </semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ital="true" ref="true" linkmention="false" linkref="true" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">
+                                 <em>term</em>
+                                 <semx element="xref" source="_">
+                                    (
+                                    <fmt-xref target="clause1">
+                                       <span class="citesec">
+                                          <span class="fmt-element-name">Clause</span>
+                                          <semx element="autonum" source="clause1">1</semx>
+                                       </span>
+                                    </fmt-xref>
+                                    )
+                                 </semx>
+                              </semx>
+                           </fmt-concept>
+                        </li>
+                        <li>
+                           <fmt-name>
+                              <semx element="autonum" source="">—</semx>
+                           </fmt-name>
+                           <concept ital="true" ref="true" linkmention="false" linkref="false" id="_">
+                              <refterm>term</refterm>
+                              <renderterm>term</renderterm>
+                              <xref target="clause1" id="_"/>
+                           </concept>
+                           <fmt-concept>
+                              <semx element="concept" source="_">
+                                 <em>term</em>
+                                 <semx element="xref" source="_">
+                                    (
+                                    <span class="citesec">
+                                       <span class="fmt-element-name">Clause</span>
+                                       <semx element="autonum" source="clause1">1</semx>
+                                    </span>
+                                    )
+                                 </semx>
+                              </semx>
+                           </fmt-concept>
+                        </li>
+                     </ul>
+                  </p>
+               </term>
+            </terms>
+         </sections>
+      </iso-standard>
     OUTPUT
     output = <<~OUTPUT
         #{HTML_HDR}

--- a/spec/isodoc/ref_spec.rb
+++ b/spec/isodoc/ref_spec.rb
@@ -184,9 +184,7 @@ RSpec.describe IsoDoc do
                       <fmt-xref target="ISO16634">
                          <span class="stdpublisher">ISO </span>
                          <span class="stddocNumber">16634</span>
-                         :-- 
-                         <span class="stdpublisher">(all </span>
-                         <span class="stdpublisher">parts)</span>
+                         :--
                       </fmt-xref>
                    </semx>
                    <eref bibitemid="ref1" id="_"/>
@@ -269,9 +267,7 @@ RSpec.describe IsoDoc do
                    <biblio-tag>
                       <span class="stdpublisher">ISO </span>
                       <span class="stddocNumber">16634</span>
-                      :-- 
-                      <span class="stdpublisher">(all </span>
-                      <span class="stdpublisher">parts)</span>
+                      :-- (all parts)
                       <fn reference="1" original-reference="1" id="_" target="_">
                          <p>Under preparation. (Stage at the time of publication ISO/DIS 16634)</p>
                          <fmt-fn-label>
@@ -525,9 +521,7 @@ RSpec.describe IsoDoc do
                       <a href="#ISO16634">
                          <span class="stdpublisher">ISO </span>
                          <span class="stddocNumber">16634</span>
-                         :-- 
-                         <span class="stdpublisher">(all </span>
-                         <span class="stdpublisher">parts)</span>
+                         :--
                       </a>
                       <a href="#ref1">ICC 167</a>
                       <a href="#ref10">[4]</a>
@@ -548,9 +542,7 @@ RSpec.describe IsoDoc do
                    <p id="ISO16634" class="NormRef">
                       <span class="stdpublisher">ISO </span>
                       <span class="stddocNumber">16634</span>
-                      :-- 
-                      <span class="stdpublisher">(all </span>
-                      <span class="stdpublisher">parts)</span>
+                      :-- (all parts)
                       <a class="FootnoteRef" href="#fn:1">
                          <sup>1</sup>
                       </a>

--- a/spec/isodoc/table_spec.rb
+++ b/spec/isodoc/table_spec.rb
@@ -220,8 +220,7 @@ RSpec.describe IsoDoc do
                          </fmt-origin>
                       </semx>
                       —
-                      <semx element="modification" source="_">with adjustments</semx>
-                      ]
+                      with adjustments]
                    </source>
                    <note type="requirement" unnumbered="true">
                   <p>This is a requirement about rice</p>

--- a/spec/isodoc/terms_spec.rb
+++ b/spec/isodoc/terms_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe IsoDoc do
                              <referenceFrom>3.1</referenceFrom>
                           </locality>
                        </origin>
-                       <modification>
+                       <modification id="_">
                           <p original-id="_">The term "cargo rice" is shown as deprecated, and Note 1 to entry is not included here</p>
                        </modification>
                     </termsource>
@@ -903,175 +903,175 @@ RSpec.describe IsoDoc do
       </term>
     INPUT
     output = <<~OUTPUT
-        <terms id="terms_and_definitions" obligation="normative" displayorder="2">
-           <title id="_">Terms and Definitions</title>
-           <fmt-title depth="1">
-              <span class="fmt-caption-label">
-                 <semx element="autonum" source="terms_and_definitions">1</semx>
-              </span>
-              <span class="fmt-caption-delim">
-                 <tab/>
-              </span>
-              <semx element="title" source="_">Terms and Definitions</semx>
-           </fmt-title>
-           <fmt-xref-label>
-              <span class="fmt-element-name">Clause</span>
-              <semx element="autonum" source="terms_and_definitions">1</semx>
-           </fmt-xref-label>
-           <p>For the purposes of this document, the following terms and definitions apply.</p>
-           <term id="paddy1">
-              <fmt-name>
-                 <span class="fmt-caption-label">
-                    <semx element="autonum" source="terms_and_definitions">1</semx>
-                    <span class="fmt-autonum-delim">.</span>
-                    <semx element="autonum" source="paddy1">1</semx>
-                 </span>
-              </fmt-name>
-              <fmt-xref-label>
-                 <semx element="autonum" source="terms_and_definitions">1</semx>
-                 <span class="fmt-autonum-delim">.</span>
-                 <semx element="autonum" source="paddy1">1</semx>
-              </fmt-xref-label>
-              <preferred id="_">
-                 <expression>
-                    <name>paddy</name>
-                 </expression>
-              </preferred>
-              <fmt-preferred>
-                 <p>
-                    <semx element="preferred" source="_">
-                       <strong>paddy</strong>
-                    </semx>
-                 </p>
-              </fmt-preferred>
-              <definition id="_">
-                 <verbal-definition>
-                    <p original-id="_">rice retaining its husk after threshing</p>
-                 </verbal-definition>
-              </definition>
-              <fmt-definition>
-                 <semx element="definition" source="_">
-                    <p id="_">rice retaining its husk after threshing</p>
-                 </semx>
-              </fmt-definition>
-              <termsource status="identical" id="_">
-                 <origin citeas="">
-                    <termref base="IEV" target="xyz">t1</termref>
-                 </origin>
-                 <modification>
-                    <p original-id="_">with adjustments</p>
-                 </modification>
-              </termsource>
-              <termsource status="adapted" id="_">
-                 <origin citeas="">
-                    <termref base="IEV" target="xyz"/>
-                 </origin>
-                 <modification>
-                    <p original-id="_">with adjustments</p>
-                 </modification>
-              </termsource>
-              <termsource status="modified" id="_">
-                 <origin citeas="">
-                    <termref base="IEV" target="xyz"/>
-                 </origin>
-                 <modification>
-                    <p original-id="_">with adjustments</p>
-                 </modification>
-              </termsource>
-              <termsource status="identical" id="_">
-                 <origin citeas="">
-                    <termref base="IEV" target="xyz">t1</termref>
-                 </origin>
-              </termsource>
-              <termsource status="adapted" id="_">
-                 <origin citeas="">
-                    <termref base="IEV" target="xyz"/>
-                 </origin>
-              </termsource>
-              <termsource status="modified" id="_">
-                 <origin citeas="">
-                    <termref base="IEV" target="xyz"/>
-                 </origin>
-              </termsource>
-              <fmt-termsource status="identical">
-                 [SOURCE:
-                 <semx element="termsource" source="_">
-                    <origin citeas="" id="_">
-                       <termref base="IEV" target="xyz">t1</termref>
-                    </origin>
-                    <semx element="origin" source="_">
-                       <fmt-origin citeas="">
-                          <termref base="IEV" target="xyz">t1</termref>
-                       </fmt-origin>
-                    </semx>
-                    —
-                    <semx element="modification" source="_">with adjustments</semx>
-                 </semx>
-                 ;
-                 <semx element="termsource" source="_">
-                    <origin citeas="" id="_">
-                       <termref base="IEV" target="xyz"/>
-                    </origin>
-                    <semx element="origin" source="_">
-                       <fmt-origin citeas="">
-                          <termref base="IEV" target="xyz"/>
-                       </fmt-origin>
-                    </semx>
-                    , modified —
-                    <semx element="modification" source="_">with adjustments</semx>
-                 </semx>
-                 ;
-                 <semx element="termsource" source="_">
-                    <origin citeas="" id="_">
-                       <termref base="IEV" target="xyz"/>
-                    </origin>
-                    <semx element="origin" source="_">
-                       <fmt-origin citeas="">
-                          <termref base="IEV" target="xyz"/>
-                       </fmt-origin>
-                    </semx>
-                    , modified —
-                    <semx element="modification" source="_">with adjustments</semx>
-                 </semx>
-                 ;
-                 <semx element="termsource" source="_">
-                    <origin citeas="" id="_">
-                       <termref base="IEV" target="xyz">t1</termref>
-                    </origin>
-                    <semx element="origin" source="_">
-                       <fmt-origin citeas="">
-                          <termref base="IEV" target="xyz">t1</termref>
-                       </fmt-origin>
-                    </semx>
-                 </semx>
-                 ;
-                 <semx element="termsource" source="_">
-                    <origin citeas="" id="_">
-                       <termref base="IEV" target="xyz"/>
-                    </origin>
-                    <semx element="origin" source="_">
-                       <fmt-origin citeas="">
-                          <termref base="IEV" target="xyz"/>
-                       </fmt-origin>
-                    </semx>
-                    , modified
-                 </semx>
-                 ;
-                 <semx element="termsource" source="_">
-                    <origin citeas="" id="_">
-                       <termref base="IEV" target="xyz"/>
-                    </origin>
-                    <semx element="origin" source="_">
-                       <fmt-origin citeas="">
-                          <termref base="IEV" target="xyz"/>
-                       </fmt-origin>
-                    </semx>
-                    , modified
-                 </semx>
-                 ]
-              </fmt-termsource>
-           </term>
-        </terms>
+       <terms id="terms_and_definitions" obligation="normative" displayorder="2">
+          <title id="_">Terms and Definitions</title>
+          <fmt-title depth="1">
+             <span class="fmt-caption-label">
+                <semx element="autonum" source="terms_and_definitions">1</semx>
+             </span>
+             <span class="fmt-caption-delim">
+                <tab/>
+             </span>
+             <semx element="title" source="_">Terms and Definitions</semx>
+          </fmt-title>
+          <fmt-xref-label>
+             <span class="fmt-element-name">Clause</span>
+             <semx element="autonum" source="terms_and_definitions">1</semx>
+          </fmt-xref-label>
+          <p>For the purposes of this document, the following terms and definitions apply.</p>
+          <term id="paddy1">
+             <fmt-name>
+                <span class="fmt-caption-label">
+                   <semx element="autonum" source="terms_and_definitions">1</semx>
+                   <span class="fmt-autonum-delim">.</span>
+                   <semx element="autonum" source="paddy1">1</semx>
+                </span>
+             </fmt-name>
+             <fmt-xref-label>
+                <semx element="autonum" source="terms_and_definitions">1</semx>
+                <span class="fmt-autonum-delim">.</span>
+                <semx element="autonum" source="paddy1">1</semx>
+             </fmt-xref-label>
+             <preferred id="_">
+                <expression>
+                   <name>paddy</name>
+                </expression>
+             </preferred>
+             <fmt-preferred>
+                <p>
+                   <semx element="preferred" source="_">
+                      <strong>paddy</strong>
+                   </semx>
+                </p>
+             </fmt-preferred>
+             <definition id="_">
+                <verbal-definition>
+                   <p original-id="_">rice retaining its husk after threshing</p>
+                </verbal-definition>
+             </definition>
+             <fmt-definition>
+                <semx element="definition" source="_">
+                   <p id="_">rice retaining its husk after threshing</p>
+                </semx>
+             </fmt-definition>
+             <termsource status="identical" id="_">
+                <origin citeas="">
+                   <termref base="IEV" target="xyz">t1</termref>
+                </origin>
+                <modification id="_">
+                   <p original-id="_">with adjustments</p>
+                </modification>
+             </termsource>
+             <termsource status="adapted" id="_">
+                <origin citeas="">
+                   <termref base="IEV" target="xyz"/>
+                </origin>
+                <modification id="_">
+                   <p original-id="_">with adjustments</p>
+                </modification>
+             </termsource>
+             <termsource status="modified" id="_">
+                <origin citeas="">
+                   <termref base="IEV" target="xyz"/>
+                </origin>
+                <modification id="_">
+                   <p original-id="_">with adjustments</p>
+                </modification>
+             </termsource>
+             <termsource status="identical" id="_">
+                <origin citeas="">
+                   <termref base="IEV" target="xyz">t1</termref>
+                </origin>
+             </termsource>
+             <termsource status="adapted" id="_">
+                <origin citeas="">
+                   <termref base="IEV" target="xyz"/>
+                </origin>
+             </termsource>
+             <termsource status="modified" id="_">
+                <origin citeas="">
+                   <termref base="IEV" target="xyz"/>
+                </origin>
+             </termsource>
+             <fmt-termsource status="identical">
+                [SOURCE:
+                <semx element="termsource" source="_">
+                   <origin citeas="" id="_">
+                      <termref base="IEV" target="xyz">t1</termref>
+                   </origin>
+                   <semx element="origin" source="_">
+                      <fmt-origin citeas="">
+                         <termref base="IEV" target="xyz">t1</termref>
+                      </fmt-origin>
+                   </semx>
+                   —
+                   <semx element="modification" source="_">with adjustments</semx>
+                </semx>
+                ;
+                <semx element="termsource" source="_">
+                   <origin citeas="" id="_">
+                      <termref base="IEV" target="xyz"/>
+                   </origin>
+                   <semx element="origin" source="_">
+                      <fmt-origin citeas="">
+                         <termref base="IEV" target="xyz"/>
+                      </fmt-origin>
+                   </semx>
+                   , modified —
+                   <semx element="modification" source="_">with adjustments</semx>
+                </semx>
+                ;
+                <semx element="termsource" source="_">
+                   <origin citeas="" id="_">
+                      <termref base="IEV" target="xyz"/>
+                   </origin>
+                   <semx element="origin" source="_">
+                      <fmt-origin citeas="">
+                         <termref base="IEV" target="xyz"/>
+                      </fmt-origin>
+                   </semx>
+                   , modified —
+                   <semx element="modification" source="_">with adjustments</semx>
+                </semx>
+                ;
+                <semx element="termsource" source="_">
+                   <origin citeas="" id="_">
+                      <termref base="IEV" target="xyz">t1</termref>
+                   </origin>
+                   <semx element="origin" source="_">
+                      <fmt-origin citeas="">
+                         <termref base="IEV" target="xyz">t1</termref>
+                      </fmt-origin>
+                   </semx>
+                </semx>
+                ;
+                <semx element="termsource" source="_">
+                   <origin citeas="" id="_">
+                      <termref base="IEV" target="xyz"/>
+                   </origin>
+                   <semx element="origin" source="_">
+                      <fmt-origin citeas="">
+                         <termref base="IEV" target="xyz"/>
+                      </fmt-origin>
+                   </semx>
+                   , modified
+                </semx>
+                ;
+                <semx element="termsource" source="_">
+                   <origin citeas="" id="_">
+                      <termref base="IEV" target="xyz"/>
+                   </origin>
+                   <semx element="origin" source="_">
+                      <fmt-origin citeas="">
+                         <termref base="IEV" target="xyz"/>
+                      </fmt-origin>
+                   </semx>
+                   , modified
+                </semx>
+                ]
+             </fmt-termsource>
+          </term>
+       </terms>
     OUTPUT
     expect(Xml::C14n.format(strip_guid(Nokogiri::XML(IsoDoc::Iso::PresentationXMLConvert
           .new(presxml_options)

--- a/spec/requirements/requirements_spec.rb
+++ b/spec/requirements/requirements_spec.rb
@@ -165,9 +165,9 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
           <table id="A1">
             <tbody>
               <tr>
-                <td style="text-align:left;">Object</td>
-                <td style="text-align:left;">Value</td>
-                <td style="text-align:left;">Accomplished</td>
+                <td style="text-align: left;">Object</td>
+                <td style="text-align: left;">Value</td>
+                <td style="text-align: left;">Accomplished</td>
               </tr>
             </tbody>
           </table>
@@ -274,9 +274,9 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
                       <table id="A1" unnumbered="true">
                          <tbody>
                             <tr>
-                               <td style="text-align:left;">Object</td>
-                               <td style="text-align:left;">Value</td>
-                               <td style="text-align:left;">Accomplished</td>
+                               <td style="text-align: left;">Object</td>
+                               <td style="text-align: left;">Value</td>
+                               <td style="text-align: left;">Accomplished</td>
                             </tr>
                          </tbody>
                       </table>
@@ -1064,9 +1064,9 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
           <table id="_">
             <tbody>
               <tr>
-                <td style="text-align:left;">Object</td>
-                <td style="text-align:left;">Value</td>
-                <td style="text-align:left;">Accomplished</td>
+                <td style="text-align: left;">Object</td>
+                <td style="text-align: left;">Value</td>
+                <td style="text-align: left;">Accomplished</td>
               </tr>
             </tbody>
           </table>
@@ -1156,9 +1156,9 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
                       <table id="_" unnumbered="true">
                          <tbody>
                             <tr>
-                               <td style="text-align:left;">Object</td>
-                               <td style="text-align:left;">Value</td>
-                               <td style="text-align:left;">Accomplished</td>
+                               <td style="text-align: left;">Object</td>
+                               <td style="text-align: left;">Value</td>
+                               <td style="text-align: left;">Accomplished</td>
                             </tr>
                          </tbody>
                       </table>
@@ -1358,9 +1358,9 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
           <table id="_">
             <tbody>
               <tr>
-                <td style="text-align:left;">Object</td>
-                <td style="text-align:left;">Value</td>
-                <td style="text-align:left;">Accomplished</td>
+                <td style="text-align: left;">Object</td>
+                <td style="text-align: left;">Value</td>
+                <td style="text-align: left;">Accomplished</td>
               </tr>
             </tbody>
           </table>
@@ -1449,9 +1449,9 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
                       <table id="_" unnumbered="true">
                          <tbody>
                             <tr>
-                               <td style="text-align:left;">Object</td>
-                               <td style="text-align:left;">Value</td>
-                               <td style="text-align:left;">Accomplished</td>
+                               <td style="text-align: left;">Object</td>
+                               <td style="text-align: left;">Value</td>
+                               <td style="text-align: left;">Accomplished</td>
                             </tr>
                          </tbody>
                       </table>
@@ -3013,12 +3013,12 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
           <table id="_">
             <tbody>
               <tr>
-                <td style="text-align:left;">Object</td>
-                <td style="text-align:left;">Value</td>
+                <td style="text-align: left;">Object</td>
+                <td style="text-align: left;">Value</td>
               </tr>
               <tr>
-                <td style="text-align:left;">Mission</td>
-                <td style="text-align:left;">Accomplished</td>
+                <td style="text-align: left;">Mission</td>
+                <td style="text-align: left;">Accomplished</td>
               </tr>
             </tbody>
           </table>
@@ -3088,12 +3088,12 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
                        <table id="_" unnumbered="true">
                           <tbody>
                              <tr>
-                                <td style="text-align:left;">Object</td>
-                                <td style="text-align:left;">Value</td>
+                                <td style="text-align: left;">Object</td>
+                                <td style="text-align: left;">Value</td>
                              </tr>
                              <tr>
-                                <td style="text-align:left;">Mission</td>
-                                <td style="text-align:left;">Accomplished</td>
+                                <td style="text-align: left;">Mission</td>
+                                <td style="text-align: left;">Accomplished</td>
                              </tr>
                           </tbody>
                        </table>
@@ -3255,12 +3255,12 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
           <table id="_">
             <tbody>
               <tr>
-                <td style="text-align:left;">Object</td>
-                <td style="text-align:left;">Value</td>
+                <td style="text-align: left;">Object</td>
+                <td style="text-align: left;">Value</td>
               </tr>
               <tr>
-                <td style="text-align:left;">Mission</td>
-                <td style="text-align:left;">Accomplished</td>
+                <td style="text-align: left;">Mission</td>
+                <td style="text-align: left;">Accomplished</td>
               </tr>
             </tbody>
           </table>
@@ -3331,12 +3331,12 @@ RSpec.describe Metanorma::Requirements::Iso::Modspec do
                        <table id="_" unnumbered="true">
                           <tbody>
                              <tr>
-                                <td style="text-align:left;">Object</td>
-                                <td style="text-align:left;">Value</td>
+                                <td style="text-align: left;">Object</td>
+                                <td style="text-align: left;">Value</td>
                              </tr>
                              <tr>
-                                <td style="text-align:left;">Mission</td>
-                                <td style="text-align:left;">Accomplished</td>
+                                <td style="text-align: left;">Mission</td>
+                                <td style="text-align: left;">Accomplished</td>
                              </tr>
                           </tbody>
                        </table>


### PR DESCRIPTION
…o not mark up (all parts) as publisher span: https://github.com/metanorma/mn-samples-icc/issues/16

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
