### PR TITLE
preserve 'Annex A' prefix in pre-refresh Word ToC: https://github.com…

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,2 +1,2 @@
 gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
-gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/corporate-author"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"

--- a/spec/isodoc/postproc_spec.rb
+++ b/spec/isodoc/postproc_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe IsoDoc do
                       </clause>
                     </clause>
                   </sections>
-                  <annex id="AA" displayorder="2"><fmt-title id="_">Annex A<tab/>Annex First</fmt-title></annex>
+                  <annex id="AA" displayorder="2"><fmt-title id="_">Annex First</fmt-title></annex>
                 </iso-standard>
       INPUT
 


### PR DESCRIPTION
…/metanorma/metanorma-ieee/issues/599

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
