### PR TITLE
Update French monthyear fixture to CLDR sentence case

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,3 +1,5 @@
+gem "isodoc-i18n", git: "https://github.com/metanorma/isodoc-i18n", branch: "feature/format-iso-date-helper"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "feature/format-iso-date-delegation"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "main"
 gem "metanorma-plugin-lutaml", git: "https://github.com/metanorma/metanorma-plugin-lutaml", branch: "fix/ruby-4.0"
 

--- a/spec/isodoc/amd_spec.rb
+++ b/spec/isodoc/amd_spec.rb
@@ -1199,7 +1199,7 @@ RSpec.describe IsoDoc do
         lang: "fr",
         publisher: "International Organization for Standardization",
         revdate: "2000-01-01",
-        revdate_monthyear: "Janvier 2000",
+        revdate_monthyear: "janvier 2000",
         script: "Latn",
         stage: "10",
         stage_int: 10,


### PR DESCRIPTION
Part of metanorma/metanorma-plateau#147 (Phase 3 — flavour-copies refactor). Downstream of metanorma/isodoc#792. Updates `amd_spec.rb:1202` French `revdate_monthyear` fixture from `"Janvier 2000"` → `"janvier 2000"` (CLDR-canonical sentence case); pins `isodoc-i18n` + `isodoc` to their Phase 3 PR branches in `Gemfile.devel`.
