### PR TITLE
Support the ISO Supplement document type

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,6 @@
+gem "metanorma-cli"
+
+# metanorma-iso#1562 Supplement doctype depends on the standoc title_nums_prep
+# change; track the PR branch until it is released.
+gem "metanorma-standoc", github: "metanorma/metanorma-standoc",
+                         branch: "feature/supplement-doctype"

--- a/lib/isodoc/iso/html/html_iso_titlepage.html
+++ b/lib/isodoc/iso/html/html_iso_titlepage.html
@@ -46,6 +46,9 @@
 {% if doctitleaddlabel %}
 <div class="doctitle-part">{{ doctitleaddlabel }}{% if doctitleadd %}: {{ doctitleadd }}{% endif %}</div>
 {% endif %}
+{% if doctitlesuplabel %}
+<div class="doctitle-part">{{ doctitlesuplabel }}{% if doctitlesup %}: {{ doctitlesup }}{% endif %}</div>
+{% endif %}
 {% if doctitlecorrlabel %}
 <div class="doctitle-part">{{ doctitlecorrlabel }}</div>
 {% endif %}

--- a/lib/isodoc/iso/html/word_iso_titlepage-dis.html
+++ b/lib/isodoc/iso/html/word_iso_titlepage-dis.html
@@ -34,6 +34,10 @@
 <p class="zzCover"><b>{{ doctitleaddlabel }}</b></p>
 {% endif %}
 
+{% if doctitlesuplabel %}
+<p class="zzCover"><b>{{ doctitlesuplabel }}</b></p>
+{% endif %}
+
 {% if doctitlecorrlabel %}
 <p class="zzCover"><b>{{ doctitlecorrlabel }}</b></p>
 {% endif %}
@@ -51,6 +55,9 @@
 {% endif %}
 {% if doctitleaddlabel %}
 <p class="zzCover"><b>{{ doctitleaddlabel }}{% if doctitleadd %}: {{ doctitleadd }}{% endif %}</b></p>
+{% endif %}
+{% if doctitlesuplabel %}
+<p class="zzCover"><b>{{ doctitlesuplabel }}{% if doctitlesup %}: {{ doctitlesup }}{% endif %}</b></p>
 {% endif %}
 {% if doctitlecorrlabel %}
 <p class="zzCover"><b>{{ doctitlecorrlabel }}</b></p>

--- a/lib/isodoc/iso/html/word_iso_titlepage-prf.html
+++ b/lib/isodoc/iso/html/word_iso_titlepage-prf.html
@@ -28,6 +28,10 @@
 <p class="zzCover"><b>{{ doctitleaddlabel }}</b></p>
 {% endif %}
 
+{% if doctitlesuplabel %}
+<p class="zzCover"><b>{{ doctitlesuplabel }}</b></p>
+{% endif %}
+
 {% if doctitlecorrlabel %}
 <p class="zzCover"><b>{{ doctitlecorrlabel }}</b></p>
 {% endif %}
@@ -45,6 +49,9 @@
 {% endif %}
 {% if doctitleaddlabel %}
 <p class="zzCover"><b>{{ doctitleaddlabel }}{% if doctitleadd %}: {{ doctitleadd }}{% endif %}</b></p>
+{% endif %}
+{% if doctitlesuplabel %}
+<p class="zzCover"><b>{{ doctitlesuplabel }}{% if doctitlesup %}: {{ doctitlesup }}{% endif %}</b></p>
 {% endif %}
 {% if doctitlecorrlabel %}
 <p class="zzCover"><b>{{ doctitlecorrlabel }}</b></p>

--- a/lib/isodoc/iso/html/word_iso_titlepage.html
+++ b/lib/isodoc/iso/html/word_iso_titlepage.html
@@ -22,6 +22,10 @@ style='mso-bidi-font-weight:normal'><span lang="EN-GB" style='font-size:14.0pt'>
 <p class="MsoNormal" align="right" style='text-align:right'><b>{{ doctitleaddlabel }}</b></p>
 {% endif %}
 
+{% if doctitlesuplabel %}
+<p class="MsoNormal" align="right" style='text-align:right'><b>{{ doctitlesuplabel }}</b></p>
+{% endif %}
+
 {% if doctitlecorrlabel %}
 <p class="MsoNormal" align="right" style='text-align:right'><b>{{ doctitlecorrlabel }}</b></p>
 {% endif %}
@@ -60,6 +64,9 @@ style='mso-no-proof:yes'>{{ editorialgroup }}</span></p>
 {% endif %}
 {% if doctitleaddlabel %}
 <p class="MsoNormal" style='text-align:left;line-height:18.0pt;margin-bottom:0.0pt;margin-top:6.0pt;font-size:16.0pt'>{{ doctitleaddlabel }}{% if doctitleadd %}: {{ doctitleadd }}{% endif %}</p>
+{% endif %}
+{% if doctitlesuplabel %}
+<p class="MsoNormal" style='text-align:left;line-height:18.0pt;margin-bottom:0.0pt;margin-top:6.0pt;font-size:16.0pt'>{{ doctitlesuplabel }}{% if doctitlesup %}: {{ doctitlesup }}{% endif %}</p>
 {% endif %}
 {% if doctitlecorrlabel %}
 <p class="MsoNormal" style='text-align:left;line-height:18.0pt;margin-bottom:0.0pt;margin-top:6.0pt;font-size:16.0pt'>{{ doctitlecorrlabel }}</p>

--- a/lib/isodoc/iso/i18n-de.yaml
+++ b/lib/isodoc/iso/i18n-de.yaml
@@ -48,6 +48,7 @@ doctype_dict:
   guide: Leitfaden
   amendment: Änderung
   addendum: Nachtrag
+  supplement: Beiblatt
   technical-corrigendum: Technische Berichtigung
   directive: Richtlinie
   committee-document: Ausschussdokument

--- a/lib/isodoc/iso/i18n-en.yaml
+++ b/lib/isodoc/iso/i18n-en.yaml
@@ -44,6 +44,7 @@ title_prefixes:
   amendment: "AMENDMENT {{ var1 }}"
   corrigendum: "TECHNICAL CORRIGENDUM {{ var1 }}"
   addendum: "ADDENDUM {{ var1 }}"
+  supplement: "SUPPLEMENT {{ var1 }}"
 doctype_dict:
   international-standard: International Standard
   technical-specification: Technical Specification
@@ -53,6 +54,7 @@ doctype_dict:
   guide: Guide
   amendment: Amendment
   addendum: Addendum
+  supplement: Supplement
   technical-corrigendum: Technical Corrigendum
   directive: Directive
   committee-document: Committee Document

--- a/lib/isodoc/iso/i18n-fr.yaml
+++ b/lib/isodoc/iso/i18n-fr.yaml
@@ -42,6 +42,7 @@ title_prefixes:
   amendment: "AMENDEMENT {{ var1 }}"
   corrigendum: "RECTIFICATIF TECHNIQUE {{ var1 }}"
   addendum: "ADDITIF {{ var1 }}"
+  supplement: "SUPPLÉMENT {{ var1 }}"
 doctype_dict:
   international-standard: Norme internationale
   technical-specification: Spécification technique
@@ -51,6 +52,7 @@ doctype_dict:
   guide: Guide
   amendment: Amendement
   addendum: Additif
+  supplement: Supplément
   technical-corrigendum: Rectificatif technique
   directive: Directive
   committee-document: Document du comité

--- a/lib/isodoc/iso/i18n-ru.yaml
+++ b/lib/isodoc/iso/i18n-ru.yaml
@@ -42,6 +42,7 @@ title_prefixes:
   amendment: "ПОПРАВКА {{ var1 }}"
   corrigendum: "ТЕХНИЧЕСКОЕ ИСПРАВЛЕНИЕ {{ var1 }}"
   addendum: "ДОПОЛНЕНИЕ {{ var1 }}"
+  supplement: "ПРИБАВЛЕНИЕ {{ var1 }}"
 doctype_dict:
   international-standard: Международный Стандарт
   technical-specification: Техническая Спецификация
@@ -51,6 +52,7 @@ doctype_dict:
   guide: Руководство
   amendment: Поправка
   addendum: Дополнение
+  supplement: Прибавление
   technical-corrigendum: Техническое Исправление
   directive: Директива
   committee-document: Документ комитета

--- a/lib/isodoc/iso/i18n-zh-Hans.yaml
+++ b/lib/isodoc/iso/i18n-zh-Hans.yaml
@@ -33,6 +33,7 @@ doctype_dict:
   guide: 指南
   amendment: 修正
   addendum: 附录
+  supplement: 补充
   technical-corrigendum: 技术勘误
   directive: 指令
   committee-document: 委员会文件

--- a/lib/isodoc/iso/metadata.rb
+++ b/lib/isodoc/iso/metadata.rb
@@ -92,11 +92,12 @@ module IsoDoc
           subpart: isoxml.at(ns("#{prefix}/@subpart")),
           amd: isoxml.at(ns("#{prefix}/@amendment")),
           add: isoxml.at(ns("#{prefix}/@addendum")),
+          sup: isoxml.at(ns("#{prefix}/@supplement")),
           corr: isoxml.at(ns("#{prefix}/@corrigendum")) }
       end
 
       def title_parts(isoxml, lang)
-        %w(intro main complementary part amd add).each_with_object({}) do |w, m|
+        %w(intro main complementary part amd add sup).each_with_object({}) do |w, m|
           m[w.to_sym] = isoxml.at(ns("//bibdata/title[@type='title-#{w}' and " \
                                      "@language='#{lang}']"))
         end
@@ -123,6 +124,9 @@ module IsoDoc
         tn[:add] and set(:doctitleaddlabel,
                          title_part_prefix(isoxml, "addendum", lang))
         tp[:add] and set(:doctitleadd, to_xml(tp[:add].children))
+        tn[:sup] and set(:doctitlesuplabel,
+                         title_part_prefix(isoxml, "supplement", lang))
+        tp[:sup] and set(:doctitlesup, to_xml(tp[:sup].children))
         main = compose_title(tp, tn, lang)
         set(:doctitle, main)
       end
@@ -144,6 +148,9 @@ module IsoDoc
         tn[:add] and set(:docsubtitleaddlabel,
                          title_part_prefix(isoxml, "addendum", lang))
         tp[:add] and set(:docsubtitleadd, to_xml(tp[:add].children))
+        tn[:sup] and set(:docsubtitlesuplabel,
+                         title_part_prefix(isoxml, "supplement", lang))
+        tp[:sup] and set(:docsubtitlesup, to_xml(tp[:sup].children))
         tn[:corr] and set(:docsubtitlecorrlabel,
                           title_part_prefix(isoxml, "corrigendum", lang))
         main = compose_title(tp, tn, lang)

--- a/lib/metanorma/iso/cleanup_biblio.rb
+++ b/lib/metanorma/iso/cleanup_biblio.rb
@@ -18,7 +18,8 @@ module Metanorma
       # ISO as a prefix goes first
       def docidentifier_cleanup(xml)
         prefix = get_id_prefix(xml)
-        amd = @amd || xml.at("//bibdata/ext/doctype")&.text == "addendum"
+        amd = @amd ||
+          %w(addendum supplement).include?(xml.at("//bibdata/ext/doctype")&.text)
         id = xml.at("//bibdata/ext/structuredidentifier/project-number") and
           id.content =
             id_prefix(prefix, id, amd:)

--- a/lib/metanorma/iso/front.rb
+++ b/lib/metanorma/iso/front.rb
@@ -79,11 +79,12 @@ module Metanorma
       end
 
       def title_full(node, xml, lang)
-        title, intro, part, amd, add = title_full_prep(node, lang)
+        title, intro, part, amd, add, sup = title_full_prep(node, lang)
         title = "#{intro} -- #{title}" if intro
         title = "#{title} -- #{part}" if part
         title = "#{title} -- #{amd}" if amd
         title = "#{title} -- #{add}" if add
+        title = "#{title} -- #{sup}" if sup
         add_title_xml(xml, title, lang, "main")
       end
 
@@ -95,7 +96,9 @@ module Metanorma
         @amd and amd = node.attr("title-amendment-#{lang}")
         node.attr("addendum-number") and
           add = node.attr("title-addendum-#{lang}")
-        [title, intro, part, amd, add].map { |x| x&.empty? ? nil : x }
+        node.attr("supplement-number") and
+          sup = node.attr("title-supplement-#{lang}")
+        [title, intro, part, amd, add, sup].map { |x| x&.empty? ? nil : x }
       end
 
       def title(node, xml)
@@ -115,6 +118,9 @@ module Metanorma
         node.attr("addendum-number") and
           title_component(node, xml, lang,
                           { name: "addendum", abbr: "add" })
+        node.attr("supplement-number") and
+          title_component(node, xml, lang,
+                          { name: "supplement", abbr: "sup" })
         title_nums(node, xml, lang)
       end
 

--- a/lib/metanorma/iso/front_id.rb
+++ b/lib/metanorma/iso/front_id.rb
@@ -28,6 +28,7 @@ module Metanorma
       def get_typeabbr(node, amd: false)
         node.attr("amendment-number") and return :amd
         node.attr("addendum-number") and return :add
+        node.attr("supplement-number") and return :sup
         node.attr("corrigendum-number") and return :cor
         DOCTYPE2HASHID[doctype(node).to_sym]
       end
@@ -103,7 +104,8 @@ module Metanorma
         stage = iso_id_stage(node)
         ret = { number: node.attr("amendment-number") ||
           node.attr("corrigendum-number") ||
-          node.attr("addendum-number"),
+          node.attr("addendum-number") ||
+          node.attr("supplement-number"),
                 year: iso_id_year(node),
                 iteration: node.attr("iteration") }
         iso_id_stage_populate(ret, node, stage)
@@ -144,7 +146,8 @@ module Metanorma
       def iso_id_params_resolve(params, params2, node, orig_id)
         if orig_id && (node.attr("amendment-number") ||
             node.attr("corrigendum-number") ||
-                      node.attr("addendum-number"))
+                      node.attr("addendum-number") ||
+                      node.attr("supplement-number"))
           %i(unpublished part).each { |x| params.delete(x) }
           params2[:base] = orig_id
         elsif orig_id &&

--- a/lib/metanorma/iso/relaton-iso.rng
+++ b/lib/metanorma/iso/relaton-iso.rng
@@ -44,6 +44,7 @@
         <value>directive</value>
         <value>committee-document</value>
         <value>addendum</value>
+        <value>supplement</value>
       </choice>
     </define>
     <define name="DocumentSubtype">

--- a/lib/metanorma/iso/validate.rb
+++ b/lib/metanorma/iso/validate.rb
@@ -53,7 +53,7 @@ module Metanorma
         %w(international-standard technical-specification technical-report
            publicly-available-specification international-workshop-agreement
            guide amendment technical-corrigendum committee-document addendum
-           recommendation)
+           supplement recommendation)
           .include? @doctype or
           @log.add("ISO_5", nil, params: [@doctype])
       end

--- a/spec/isodoc/amd_spec.rb
+++ b/spec/isodoc/amd_spec.rb
@@ -1365,6 +1365,159 @@ RSpec.describe IsoDoc do
       .to be_equivalent_to output
   end
 
+  it "processes IsoXML metadata for supplement" do
+    c = IsoDoc::Iso::HtmlConvert.new({})
+    _ = c.convert_init(<<~INPUT, "test", false)
+      <iso-standard xmlns="http://riboseinc.com/isoxml">
+    INPUT
+    input = <<~INPUT
+      <iso-standard xmlns="https://www.metanorma.org/ns/standoc">
+        <bibdata type="standard">
+          <title format="text/plain" language="en" type="main">Introduction — Main Title — Title — Title Part  — Mass fraction of
+                   extraneous matter, milled rice (nonglutinous), sample dividers and
+                   recommendations relating to storage and transport conditions</title>
+          <title format="text/plain" language="en" type="title-intro">Introduction</title>
+          <title format="text/plain" language="en" type="title-main">Main Title — Title</title>
+          <title format="text/plain" language="en" type="title-part">Title Part</title>
+          <title format="text/plain" language="en" type="title-part-prefix">Part&#xa0;1</title>
+          <title format="text/plain" language="en" type="title-supplement-prefix">SUPPLEMENT&#xa0;1</title>
+          <title format="text/plain" language="en" type="title-corrigendum-prefix">TECHNICAL CORRIGENDUM&#xa0;2</title>
+          <title format="text/plain" language="en" type="title-sup">Mass fraction of extraneous matter, milled rice (nonglutinous), sample dividers and recommendations relating to storage and transport conditions</title>
+          <title format="text/plain" language="fr" type="main">Introduction Française — Titre Principal — Part du Titre — Fraction
+              massique de matière étrangère, riz usiné (non gluant), diviseurs
+              d’échantillon et recommandations relatives aux conditions d’entreposage et
+              de transport
+            </title>
+          <title format="text/plain" language="fr" type="title-intro">Introduction Française</title>
+          <title format="text/plain" language="fr" type="title-main">Titre Principal</title>
+          <title format="text/plain" language="fr" type="title-part">Part du Titre</title>
+          <title format="text/plain" language="fr" type="title-part-prefix">Partie&#xa0;1</title>
+          <title format="text/plain" language="fr" type="title-supplement-prefix">SUPPLÉMENT&#xa0;1</title>
+          <title format="text/plain" language="fr" type="title-corrigendum-prefix">RECTIFICATIF TECHNIQUE&#xa0;2</title>
+          <title format="text/plain" language="fr" type="title-sup">Fraction massique de matière étrangère, riz usiné (non gluant), diviseurs d’échantillon et recommandations relatives aux conditions d’entreposage et de transport</title>
+          <docidentifier type="ISO">ISO/PreNWIP3 17301-1:2016/Suppl.1</docidentifier>
+          <docidentifier type="iso-with-lang">ISO/PreNWIP3 17301-1:2016/Suppl.1(E)</docidentifier>
+          <docidentifier type="iso-reference">ISO/PreNWIP3 17301-1:2016/Suppl.1:2017(E)</docidentifier>
+          <docnumber>17301</docnumber>
+          <date type="created">
+            <on>2016-05-01</on>
+          </date>
+                      <date type="updated">
+               <on>2000-01-01</on>
+             </date>
+          <contributor>
+            <role type="author"/>
+            <organization>
+              <name>International Organization for Standardization</name>
+              <abbreviation>ISO</abbreviation>
+            </organization>
+          </contributor>
+          <contributor>
+            <role type="publisher"/>
+            <organization>
+              <name>International Organization for Standardization</name>
+              <abbreviation>ISO</abbreviation>
+            </organization>
+          </contributor>
+          <edition>2</edition>
+          <version>0.3.4</version>
+          <language>en</language>
+          <script>Latn</script>
+          <status>
+            <stage abbreviation="NWIP">10</stage>
+            <substage>20</substage>
+            <iteration>3</iteration>
+          </status>
+          <copyright>
+            <from>2017</from>
+            <owner>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+              </organization>
+            </owner>
+          </copyright>
+          <ext>
+            <doctype>supplement</doctype>
+            <editorialgroup>
+              <technical-committee number="1" type="A">TC</technical-committee>
+              <technical-committee number="11" type="A1">TC1</technical-committee>
+              <subcommittee number="2" type="B">SC</subcommittee>
+              <subcommittee number="21" type="B1">SC1</subcommittee>
+              <workgroup number="3" type="C">WG</workgroup>
+              <workgroup number="31" type="C1">WG1</workgroup>
+              <secretariat>SECRETARIAT</secretariat>
+            </editorialgroup>
+            <ics>
+              <code>1</code>
+            </ics>
+            <ics>
+              <code>2</code>
+            </ics>
+            <ics>
+              <code>3</code>
+            </ics>
+            <structuredidentifier>
+              <project-number supplement="1" corrigendum="2" origyr="2016-05-01" part="1">17301</project-number>
+            </structuredidentifier>
+            <stagename>New work item proposal</stagename>
+            <updates-document-type>international-standard</updates-document-type>
+          </ext>
+        </bibdata>
+        <metanorma-extension>
+        <semantic-metadata>
+        <stage-published>false</stage-published>
+        </semantic-metadata>
+        </metanorma-extension>
+        <sections/>
+      </iso-standard>
+    INPUT
+    output =
+      { agency: "ISO",
+        createddate: "2016-05-01",
+        docnumber: "ISO/PreNWIP3 17301-1:2016/Suppl.1",
+        docnumber_lang: "ISO/PreNWIP3 17301-1:2016/Suppl.1(E)",
+        docnumber_reference: "ISO/PreNWIP3 17301-1:2016/Suppl.1:2017(E)",
+        docnumeric: "17301",
+        docsubtitle: "Introduction Française&#xa0;&#x2014; Titre Principal&#xa0;&#x2014; Partie\u00a01 : Part du Titre",
+        docsubtitlesup: "Fraction massique de matière étrangère, riz usiné (non gluant), diviseurs d’échantillon et recommandations relatives aux conditions d’entreposage et de transport",
+        docsubtitlesuplabel: "SUPPLÉMENT\u00a01",
+        docsubtitlecorrlabel: "RECTIFICATIF TECHNIQUE\u00a02",
+        docsubtitleintro: "Introduction Française",
+        docsubtitlemain: "Titre Principal",
+        docsubtitlepart: "Part du Titre",
+        docsubtitlepartlabel: "Partie\u00a01",
+        doctitle: "Introduction&#xa0;&#x2014; Main Title\u2009—\u2009Title&#xa0;&#x2014; Part\u00a01: Title Part",
+        doctitlesup: "Mass fraction of extraneous matter, milled rice (nonglutinous), sample dividers and recommendations relating to storage and transport conditions",
+        doctitlesuplabel: "SUPPLEMENT\u00a01",
+        doctitlecorrlabel: "TECHNICAL CORRIGENDUM\u00a02",
+        doctitleintro: "Introduction",
+        doctitlemain: "Main Title\u2009\u2014\u2009Title",
+        doctitlepart: "Title Part",
+        doctitlepartlabel: "Part\u00a01",
+        doctype: "Supplement",
+        doctype_display: "Supplement",
+        docyear: "2017",
+        draft: "0.3.4",
+        draftinfo: " (draft 0.3.4, 2000-01-01)",
+        edition: "2",
+        ics: "1, 2, 3",
+        lang: "en",
+        publisher: "International Organization for Standardization",
+        revdate: "2000-01-01",
+        revdate_monthyear: "January 2000",
+        script: "Latn",
+        stage: "10",
+        stage_int: 10,
+        stageabbr: "NWIP",
+        statusabbr: "PreNWIP3",
+        substage_int: "20",
+        unpublished: true,
+        updateddate: "2000-01-01" }
+    expect(metadata(c.info(Nokogiri::XML(input), nil)))
+      .to be_equivalent_to output
+  end
+
   it "processes middle title" do
     input = <<~INPUT
       <iso-standard xmlns="http://riboseinc.com/isoxml">

--- a/spec/metanorma/amd_spec.rb
+++ b/spec/metanorma/amd_spec.rb
@@ -944,4 +944,97 @@ RSpec.describe Metanorma::Iso do
     expect(strip_guid(xml.to_xml))
       .to be_xml_equivalent_to output
   end
+
+  it "processes metadata, supplement" do
+    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+      = Document title
+      Author
+      :docfile: test.adoc
+      :nodoc:
+      :novalid:
+      :no-isobib:
+      :docnumber: 17301
+      :partnumber: 1
+      :doctype: supplement
+      :updates: ISO 17301-1:2030
+      :supplement-number: 3
+      :title-main-en: Rice
+      :title-supplement-en: Mass fraction of extraneous matter, milled rice (nonglutinous), sample dividers and recommendations relating to storage and transport conditions
+      :title-main-fr: Riz
+      :title-supplement-fr: Fraction massique de matière étrangère, riz usiné (non gluant), diviseurs d’échantillon et recommandations relatives aux conditions d’entreposage et de transport
+      :updates-document-type: international-standard
+    INPUT
+    output = <<~OUTPUT
+      <metanorma type="semantic" version="#{Metanorma::Iso::VERSION}" xmlns="https://www.metanorma.org/ns/standoc" flavor="iso">
+        <bibdata type="standard">
+             <title language="en" type="main">Rice — Mass fraction of extraneous matter, milled rice (nonglutinous), sample dividers and recommendations relating to storage and transport conditions</title>
+             <title language="en" type="title-main">Rice</title>
+             <title language="en" type="title-sup">Mass fraction of extraneous matter, milled rice (nonglutinous), sample dividers and recommendations relating to storage and transport conditions</title>
+             <title language="en" type="title-part-prefix">Part 1</title>
+      <title language="en" type="title-supplement-prefix">SUPPLEMENT 3</title>
+             <title language="fr" type="main">Riz — Fraction massique de matière étrangère, riz usiné (non gluant), diviseurs d’échantillon et recommandations relatives aux conditions d’entreposage et de transport</title>
+             <title language="fr" type="title-main">Riz</title>
+             <title language="fr" type="title-sup">Fraction massique de matière étrangère, riz usiné (non gluant), diviseurs d’échantillon et recommandations relatives aux conditions d’entreposage et de transport</title>
+                   <title language="fr" type="title-part-prefix">Partie 1</title>
+      <title language="fr" type="title-supplement-prefix">SUPPLÉMENT 3</title>
+          <docidentifier type="ISO" primary="true">ISO 17301-1:2030/Suppl 3:#{Date.today.year}</docidentifier>
+          <docidentifier type="iso-reference">ISO 17301-1:2030/Suppl 3:#{Date.today.year}(E)</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-60.60:sup:iso:#{Date.today.year}:v3</docidentifier>
+          <docidentifier type="iso-undated">ISO 17301-1:2030/Suppl 3</docidentifier>
+          <docidentifier type="iso-with-lang">ISO 17301-1:2030/Suppl 3:#{Date.today.year}(en)</docidentifier>
+          <docnumber>17301</docnumber>
+          <contributor>
+            <role type="author"/>
+            <organization>
+              <name>International Organization for Standardization</name>
+              <abbreviation>ISO</abbreviation>
+            </organization>
+          </contributor>
+          <contributor>
+            <role type="authorizer"><description>Agency</description></role>
+            <organization>
+              <name>International Organization for Standardization</name>
+              <abbreviation>ISO</abbreviation>
+            </organization>
+          </contributor>
+          <contributor>
+            <role type="publisher"/>
+            <organization>
+              <name>International Organization for Standardization</name>
+              <abbreviation>ISO</abbreviation>
+            </organization>
+          </contributor>
+          <language>en</language>
+          <script>Latn</script>
+          <status>
+            <stage abbreviation="IS">60</stage>
+            <substage>60</substage>
+          </status>
+          <copyright>
+            <from>#{Time.now.year}</from>
+            <owner>
+              <organization>
+                <name>International Organization for Standardization</name>
+                <abbreviation>ISO</abbreviation>
+              </organization>
+            </owner>
+          </copyright>
+          <ext>
+            <doctype>supplement</doctype>
+            <flavor>iso</flavor>
+            <structuredidentifier>
+              <project-number supplement="3" part="1">17301</project-number>
+            </structuredidentifier>
+            <stagename abbreviation="SUP">Supplement</stagename>
+          </ext>
+        </bibdata>
+        <sections/>
+      </metanorma>
+    OUTPUT
+    xml = Nokogiri::XML(input)
+    xml.at("//xmlns:metanorma-extension")&.remove
+    xml.at("//xmlns:boilerplate")&.remove
+    expect(strip_guid(xml.to_xml))
+      .to be_xml_equivalent_to output
+  end
 end


### PR DESCRIPTION
Closes https://github.com/metanorma/metanorma-iso/issues/1562

Adds the ISO **Supplement** deliverable, modelled on Addendum — a numbered dependent document producing the PubID `ISO 17301-1:2030/Suppl 3:2026`. Full implementation breakdown in the ticket.

Depends on metanorma/metanorma-standoc#1191 (the `title_nums_prep` change), tracked via `Gemfile.devel` until released.

🤖
