### PR TITLE
chore(ci): cimas sync 2026-06-24 — required_ruby_version >= 3.3, automerge v0.16.4 pin, lutaml Makefile (refs metanorma/ci#274 #283 #281 #300)

### DIFF
--- a/metanorma-iso.gemspec
+++ b/metanorma-iso.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
     || f.match(%r{Rakefile|bin/rspec})
   end
   spec.test_files = `git ls-files -- {spec}/*`.split("\n")
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.1.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.3.0")
 
   spec.add_dependency "metanorma-standoc", "~> 3.4.2"
   spec.add_dependency "mnconvert", "~> 1.14"


### PR DESCRIPTION
As title. 

 _Generated by Cimas_.