### PR TITLE
Gate ISO/IEC stage footnotes and ISO-only behaviours on document publisher (taste-safe)

### DIFF
--- a/lib/isodoc/iso/presentation_origin.rb
+++ b/lib/isodoc/iso/presentation_origin.rb
@@ -84,15 +84,11 @@ module IsoDoc
         insert_biblio_callout(elem)
       end
 
-      # TODO share with metanorma dir
-      ISO_PUBLISHER_XPATH = <<~XPATH.freeze
-        ./contributor[role/@type = 'publisher']/organization[abbreviation = 'ISO' or abbreviation = 'IEC' or name = 'International Organization for Standardization' or name = 'International Electrotechnical Commission']
-      XPATH
-
       def insert_biblio_callout(elem)
         semx = elem.document.at("//*[@id = '#{elem['source']}']") or return
         if ref = @bibitem_lookup[semx["bibitemid"]]
-          ref.at(ns(ISO_PUBLISHER_XPATH)) and return
+          Metanorma::Iso::PublisherIdentity
+            .iso_iec_publisher?(ref, ns: method(:ns)) and return
           # is this reference cited with a [n],
           # even if it has its own SDO identifier?
           citeas = ref.at(ns("./docidentifier[@type = 'metanorma-ordinal']")) ||

--- a/lib/isodoc/iso/presentation_xml_convert.rb
+++ b/lib/isodoc/iso/presentation_xml_convert.rb
@@ -16,7 +16,11 @@ module IsoDoc
       end
 
       def convert1(docxml, filename, dir)
-        @iso_class = instance_of?(IsoDoc::Iso::PresentationXMLConvert)
+        # ISO-only (not inheriting flavours, and -- unlike instance_of? --
+        # not tastes that reuse this class): gate on the document publisher.
+        # metanorma/metanorma-oiml#13.
+        @iso_class = Metanorma::Iso::PublisherIdentity
+          .iso_publisher?(docxml.at(ns("//bibdata")), ns: method(:ns))
         if amd?(docxml)
           @oldsuppressheadingnumbers = @suppressheadingnumbers
           @suppressheadingnumbers = true

--- a/lib/isodoc/iso/word_cleanup.rb
+++ b/lib/isodoc/iso/word_cleanup.rb
@@ -181,8 +181,7 @@ module IsoDoc
       # do not use in IEC, BSI, where Word does not use list to generate
       # "Annex A"
       def annex_toc(annexid)
-        instance_of?(IsoDoc::Iso::WordConvert) ||
-          instance_of?(WordDISConvert) or return ""
+        @iso_publisher or return ""
         annexid += 1
         x = "#{@i18n.annex} #{('@'.ord + annexid).chr} "
         [x, annexid]

--- a/lib/isodoc/iso/word_convert.rb
+++ b/lib/isodoc/iso/word_convert.rb
@@ -58,6 +58,17 @@ module IsoDoc
         end
       end
 
+      # word_cleanup (make_WordToC / annex_toc) runs on the generated Word
+      # HTML, which no longer carries <bibdata>; capture the document's
+      # ISO-publisher identity here, off the source presentation XML, and
+      # propagate it via @iso_publisher. ISO-only (not IEC/BSI, and --
+      # unlike instance_of? -- not tastes reusing this class). oiml#13.
+      def convert1(docxml, filename, dir)
+        @iso_publisher = Metanorma::Iso::PublisherIdentity
+          .iso_publisher?(docxml.at(ns("//bibdata")), ns: method(:ns))
+        super
+      end
+
       def make_body(xml, docxml)
         body_attr = { lang: "EN-US", link: "blue", vlink: "#954F72" }
         xml.body(**body_attr) do |body|

--- a/lib/metanorma-iso.rb
+++ b/lib/metanorma-iso.rb
@@ -1,4 +1,5 @@
 require "asciidoctor" unless defined? Asciidoctor::Converter
+require_relative "metanorma/iso/publisher_identity"
 require_relative "metanorma/iso/converter"
 require_relative "metanorma/iso/validate"
 require_relative "metanorma/iso/cleanup"

--- a/lib/metanorma/iso/cleanup_biblio.rb
+++ b/lib/metanorma/iso/cleanup_biblio.rb
@@ -90,6 +90,11 @@ module Metanorma
 
       def bibitem_cleanup(xmldoc)
         super
+        # ISO/IEC bibliographic stage footnotes are ISO-house behaviour: only
+        # emit them when the *document itself* is published by ISO or IEC, so
+        # other flavours (JIS, BSI, …) and tastes (OIML, PDFA) do not inherit
+        # them. metanorma/metanorma-oiml#13.
+        PublisherIdentity.iso_iec_publisher?(xmldoc.at("//bibdata")) or return
         unpublished_note(xmldoc)
         withdrawn_note(xmldoc)
       end
@@ -139,7 +144,7 @@ module Metanorma
       end
 
       def unpublished_ref?(bibitem)
-        pub_class(bibitem) > 2 and return true
+        PublisherIdentity.iso_iec_publisher?(bibitem) or return true
         ((s = bibitem.at("./status/stage")) && s.text.match?(/\d/) &&
          (s.text.to_i < 60)) or return true
         false
@@ -158,7 +163,7 @@ module Metanorma
       end
 
       def withdrawn_ref?(bibitem)
-        pub_class(bibitem) > 2 and return false
+        PublisherIdentity.iso_iec_publisher?(bibitem) or return false
         (s = bibitem.at("./status/stage")) && (s.text.to_i == 95) &&
           (t = bibitem.at("./status/substage")) && (t.text.to_i == 99)
       end

--- a/lib/metanorma/iso/publisher_identity.rb
+++ b/lib/metanorma/iso/publisher_identity.rb
@@ -1,0 +1,36 @@
+module Metanorma
+  module Iso
+    # Canonical "is this node published by ISO / IEC?" check, shared across the
+    # metanorma-converter layer (bare xpath) and the isodoc layer (namespaced
+    # xpath). Pass the converter's #ns as the `ns:` resolver in the isodoc layer;
+    # the default identity resolver is correct for the un-namespaced Semantic XML
+    # of the cleanup layer. Deliberately NOT pub_class, which is sort-oriented and
+    # overridden per flavour.
+    module PublisherIdentity
+      PUBLISHER = "./contributor[role/@type = 'publisher']/organization".freeze
+      ISO_NAME = "International Organization for Standardization".freeze
+      IEC_NAME = "International Electrotechnical Commission".freeze
+      IDENTITY_NS = ->(xpath) { xpath }
+
+      module_function
+
+      def iso_publisher?(node, ns: IDENTITY_NS)
+        publisher_match?(node, ns, "ISO", ISO_NAME)
+      end
+
+      def iec_publisher?(node, ns: IDENTITY_NS)
+        publisher_match?(node, ns, "IEC", IEC_NAME)
+      end
+
+      def iso_iec_publisher?(node, ns: IDENTITY_NS)
+        iso_publisher?(node, ns: ns) || iec_publisher?(node, ns: ns)
+      end
+
+      def publisher_match?(node, ns, abbr, name)
+        node or return false
+        !!(node.at(ns.call("#{PUBLISHER}[abbreviation = '#{abbr}']")) ||
+           node.at(ns.call("#{PUBLISHER}[name = '#{name}']")))
+      end
+    end
+  end
+end

--- a/lib/metanorma/iso/validate_section.rb
+++ b/lib/metanorma/iso/validate_section.rb
@@ -177,14 +177,10 @@ module Metanorma
       NORM_BIBITEMS =
         "//references[@normative = 'true']/bibitem".freeze
 
-      ISO_PUBLISHER_XPATH = <<~XPATH.freeze
-        ./contributor[role/@type = 'publisher']/organization[abbreviation = 'ISO' or abbreviation = 'IEC' or name = 'International Organization for Standardization' or name = 'International Electrotechnical Commission']
-      XPATH
-
       # ISO/IEC DIR 2, 10.2
       def norm_bibitem_style(root)
         root.xpath(NORM_BIBITEMS).each do |b|
-          if b.at(ISO_PUBLISHER_XPATH).nil?
+          unless PublisherIdentity.iso_iec_publisher?(b)
             @log.add("ISO_42", b, params: [b.text])
           end
         end

--- a/spec/isodoc/blocks_spec.rb
+++ b/spec/isodoc/blocks_spec.rb
@@ -1327,6 +1327,7 @@ RSpec.describe IsoDoc do
   it "ignores intervening ul in numbering ol" do
     input = <<~INPUT
       <iso-standard xmlns="http://riboseinc.com/isoxml">
+      <bibdata><contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor></bibdata>
       <preface><foreword id="A">
       <ul>
       <li>A</li>
@@ -1341,6 +1342,7 @@ RSpec.describe IsoDoc do
     INPUT
     presxml = <<~INPUT
       <iso-standard xmlns="http://riboseinc.com/isoxml" type="presentation">
+         <bibdata><contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor></bibdata>
          <preface>
             <clause type="toc" id="_" displayorder="1">
                <fmt-title depth="1" id="_">Contents</fmt-title>
@@ -1378,7 +1380,8 @@ RSpec.describe IsoDoc do
     INPUT
     expect(strip_guid(IsoDoc::Iso::PresentationXMLConvert
       .new(presxml_options)
-      .convert("test", input, true)))
+      .convert("test", input, true)
+      .sub(%r{<localized-strings>.*</localized-strings>}m, "")))
       .to be_xml_equivalent_to presxml
   end
 

--- a/spec/isodoc/postproc_spec.rb
+++ b/spec/isodoc/postproc_spec.rb
@@ -305,6 +305,7 @@ RSpec.describe IsoDoc do
       .new(WORD_HTML_CSS_WORDINTRO.dup)
       .convert("test", <<~INPUT, false)
         <iso-standard xmlns="http://riboseinc.com/isoxml">
+          <bibdata><contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor></bibdata>
           <metanorma-extension>
             <presentation-metadata>
               <toc-heading-levels>3</toc-heading-levels>

--- a/spec/isodoc/word_dis_list_spec.rb
+++ b/spec/isodoc/word_dis_list_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe IsoDoc do
       <iso-standard xmlns="http://riboseinc.com/isoxml">
         <bibdata>
           <status><stage>50</stage></status>
+          <contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
         </bibdata>
         <sections>
         <clause id="A"><p>
@@ -198,6 +199,7 @@ RSpec.describe IsoDoc do
       <iso-standard xmlns="http://riboseinc.com/isoxml">
         <bibdata>
           <status><stage>50</stage></status>
+          <contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
         </bibdata>
         <sections>
         <clause id="A"><p>
@@ -297,6 +299,7 @@ RSpec.describe IsoDoc do
         <iso-standard xmlns="http://riboseinc.com/isoxml">
       <bibdata>
         <status><stage>50</stage></status>
+        <contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
       </bibdata>
       <sections>
       <clause id="A">
@@ -362,6 +365,7 @@ RSpec.describe IsoDoc do
       <iso-standard xmlns="http://riboseinc.com/isoxml">
         <bibdata>
           <status><stage>50</stage></status>
+          <contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
         </bibdata>
         <sections>
         <clause id="A"><p>
@@ -475,6 +479,7 @@ RSpec.describe IsoDoc do
       <iso-standard xmlns="http://riboseinc.com/isoxml">
         <bibdata>
           <status><stage>50</stage></status>
+          <contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
         </bibdata>
         <sections>
         <clause id="A">
@@ -592,6 +597,7 @@ RSpec.describe IsoDoc do
       <iso-standard xmlns="http://riboseinc.com/isoxml">
         <bibdata>
           <status><stage>50</stage></status>
+          <contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
         </bibdata>
         <sections>
         <clause id="A">
@@ -709,6 +715,7 @@ RSpec.describe IsoDoc do
       <iso-standard xmlns="http://riboseinc.com/isoxml">
         <bibdata>
           <status><stage>50</stage></status>
+          <contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
         </bibdata>
         <sections>
         <clause id="A">
@@ -783,6 +790,7 @@ RSpec.describe IsoDoc do
       <iso-standard xmlns="http://riboseinc.com/isoxml">
         <bibdata>
           <status><stage>50</stage></status>
+          <contributor><role type="publisher"/><organization><name>International Organization for Standardization</name><abbreviation>ISO</abbreviation></organization></contributor>
         </bibdata>
         <sections>
         <clause id="A" displayorder="1">


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-oiml/issues/13

Make ISO-house bibliographic / list / Word behaviours **taste-safe** by gating them on the document's *publisher* (bibdata) rather than on the converter class. ISO and IEC keep the behaviour (aligned); inheriting flavours (JIS/BSI/Plateau) and tastes (OIML/PDFA) suppress it.

Full diagnosis, design, and per-file narrative on the tracking issue: https://github.com/metanorma/metanorma-oiml/issues/13

## Summary
- **New** `Metanorma::Iso::PublisherIdentity` — namespace-aware `iso_publisher?` / `iec_publisher?` / `iso_iec_publisher?`, usable from both the metanorma-converter layer (bare xpath) and the isodoc layer (ns-wrapped) via an `ns:` resolver. Not `pub_class` (sort-oriented, overridden per flavour).
- **Tier 1** — stage footnotes ("Withdrawn." / "Cancelled and replaced" / "Under preparation.") gated on the document publisher.
- **Tier 2** — unify the duplicated `ISO_PUBLISHER_XPATH` and replace `pub_class > 2` ref checks.
- **Tier 3** — migrate the two `instance_of?` taste-bugs (`@iso_class` list nesting; Word `annex_toc`) to `iso_publisher?`. Word `annex_toc` runs after bibdata is gone, so the identity is captured in `WordConvert#convert1` and propagated via `@iso_publisher`.

## Test plan
- Full `metanorma-iso` suite green: **389 examples, 0 failures, 4 pending**.
- Tier-3 fixtures updated to carry an ISO publisher (real documents always do); the presentation-XML case strips the emitted `<localized-strings>` per the established idiom.
- **PDFA** confirmed unaffected on its current `ribose` base (→ `Generic::Cleanup`), which never reaches the ISO stage-note code.

🤖
