### PR TITLE
Fix HTML TOC toggle parked over the TOC text (nav appears doubled)

### DIFF
--- a/lib/isodoc/iso/html/style-human.scss
+++ b/lib/isodoc/iso/html/style-human.scss
@@ -301,8 +301,6 @@ nav {
 
 #toggle {
     @include sidebarNavToggle(white, black);
-    margin-left: -4em;
-    margin-top: -2em;
 }
 
 @media screen and (min-width: 768px) {

--- a/lib/isodoc/iso/html/style-iso.scss
+++ b/lib/isodoc/iso/html/style-iso.scss
@@ -242,8 +242,6 @@ nav {
 #toggle {
     @include sidebarNavToggle(black, #f7f7f7);
     border-right: solid black 1px;
-    margin-left: -4em;
-    margin-top: -2em;
 }
 
 @media screen and (min-width: 768px) {


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-iso/issues/1576

**Not a duplicated nav — a mispositioned toggle.** The `#toggle` sidebar show/hide strip had `margin-left: -4em; margin-top: -2em`, which parked it in the *middle* of the TOC, on top of the entries. Its `border-right: solid black 1px` drew a vertical line through the text and its opaque background split each entry, so one TOC read as two overlapping panes. This surfaced on ISO 10303 (EXPRESS) documents because their schema-name entries are long, non-breaking identifiers that run under the strip.

Removing the two offset lines (in `style-iso.scss` and `style-human.scss`) returns `#toggle` to its edge; the `border-right` stays as the intended edge divider. Diagnosed live against a Part 62 collection build — with the offsets removed the black line and the apparent doubling are gone and the entries render cleanly.

🤖
