### PR TITLE
Configurable publisher bibliography sort; decouple ISO/IEC identity

### DIFF
--- a/lib/metanorma/iso/cleanup_biblio.rb
+++ b/lib/metanorma/iso/cleanup_biblio.rb
@@ -34,29 +34,28 @@ module Metanorma
       ISO_NAME = "International Organization for Standardization".freeze
       IEC_NAME = "International Electrotechnical Commission".freeze
 
+      # Default publisher sort order for ISO documents: ISO first, IEC second,
+      # then other standards, then everything else. A metanorma-taste config or
+      # a per-document :sort-biblio-<abbrev>: attribute overrides this via the
+      # shared Standoc::Ref helpers (e.g. OIML ranks OIML ahead of ISO/IEC).
+      DEFAULT_PUBLISHER_SORT = [
+        { abbrev: "ISO", name: ISO_NAME, rank: 1 },
+        { abbrev: "IEC", name: IEC_NAME, rank: 2 },
+      ].freeze
+
       def pub_class(bib)
-        bib.at("#{PUBLISHER}[abbreviation = 'ISO']") ||
-          bib.at("#{PUBLISHER}[name = '#{ISO_NAME}']") and return 1
-        bib.at("#{PUBLISHER}[abbreviation = 'IEC']") ||
-          bib.at("#{PUBLISHER}[name = '#{IEC_NAME}']") and return 2
-        bib.at("./docidentifier[@type]" \
-               "[not(#{@conv.skip_docid} or @type = 'metanorma')]") ||
-          bib.at("./docidentifier[not(@type)]") and return 3
-        4
+        publisher_sort_rank(bib, DEFAULT_PUBLISHER_SORT)
       end
 
-      def second_pub_class(bib, first_pub)
-        case first_pub
-        when 1
-          n = bib.at("#{PUBLISHER}[not(abbreviation = 'ISO')]" \
-                     "[not(name = '#{ISO_NAME}')]")
-          n&.at("./abbreviation") || n&.at("./name") || ""
-        when 2
-          n = bib.at("#{PUBLISHER}[not(abbreviation = 'IEC')]" \
-                     "[not(name = '#{IEC_NAME}')]")
-          n&.at("./abbreviation") || n&.at("./name") || ""
-        else ""
-        end
+      def second_pub_class(bib, _first_pub = nil)
+        publisher_sort_second(bib, DEFAULT_PUBLISHER_SORT)
+      end
+
+      # ISO also ranks a reference with only an untyped docidentifier as a
+      # standards reference (historical pub_class behaviour), widening the base
+      # typed-only definition.
+      def biblio_standards_ref?(bib)
+        super || !!bib.at("./docidentifier[not(@type)]")
       end
 
       def sort_biblio(bib)
@@ -145,8 +144,13 @@ module Metanorma
       end
 
       def parse_draft_docid(docid, bibitem)
-        publisher = pub_class(bibitem)
-        base_pubid = publisher == 1 ? Pubid::Iso::Identifier : Pubid::Iec::Identifier
+        # Semantic ISO-vs-IEC identity, NOT the sort rank: pub_class is now
+        # configurable (a taste may rerank ISO below OIML), so draft docid
+        # parsing must use the publisher identity predicate directly.
+        base_pubid = if PublisherIdentity.iso_publisher?(bibitem)
+                       Pubid::Iso::Identifier
+                     else Pubid::Iec::Identifier
+                     end
         [base_pubid, base_pubid.parse(docid.text).to_h]
       end
 

--- a/spec/metanorma/refs_spec.rb
+++ b/spec/metanorma/refs_spec.rb
@@ -296,6 +296,30 @@ RSpec.describe Metanorma::Iso do
                             "ISO 8000-110", "ISO/IEC 646", "ISO/IEEE 32675"]
   end
 
+  # metanorma/metanorma-oiml#12: the publisher sort order is configurable via
+  # :sort-biblio-<abbrev>: <rank>: <name> document attributes (set directly or
+  # injected by a metanorma-taste config). The default ISO-before-IEC ordering
+  # flips when IEC is ranked ahead of ISO.
+  it "overrides the publisher sort order via :sort-biblio- attributes" do
+    hdr = ASCIIDOC_BLANK_HDR.sub(
+      ":no-isobib:\n",
+      ":no-isobib:\n" \
+      ":sort-biblio-IEC: 1: International Electrotechnical Commission\n" \
+      ":sort-biblio-ISO: 2: International Organization for Standardization\n",
+    )
+    input = <<~INPUT
+      #{hdr}
+      [bibliography]
+      == Bibliography
+
+      * [[[iso1,ISO 9]]]
+      * [[[iec1,IEC 60050]]]
+    INPUT
+    xml = Nokogiri::XML(Asciidoctor.convert(input, *OPTIONS))
+    expect(xml.xpath("//xmlns:bibliography//xmlns:docidentifier").map(&:text))
+      .to be_equivalent_to ["IEC 60050", "ISO 9"]
+  end
+
   it "renders withdrawn and cancelled ISO references" do
     input = <<~INPUT
       #{LOCAL_CACHED_ISOBIB_BLANK_HDR}


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-oiml/issues/12

`pub_class`/`second_pub_class` delegate to the shared helpers with an ISO/IEC default table. The ISO-vs-IEC *semantic* decision in `parse_draft_docid` moves to `PublisherIdentity` so re-ranking can't change draft pubid parsing. Default sort output unchanged; new spec covers the re-rank.

Part of the stack-wide configurable bibliography publisher-sort feature. The bibliography's publisher sort order becomes overridable via `:sort-biblio-<abbrev>: <rank>: <name>` document attributes — set directly in a document, or injected by a metanorma-taste config. Full diagnosis, design, per-gem breakdown and verification are on the ticket.

🤖
