### PR TITLE
Place bibliography status footnote on the designation, not the [n] ordinal

### DIFF
--- a/lib/isodoc/iso/presentation_xml_convert.rb
+++ b/lib/isodoc/iso/presentation_xml_convert.rb
@@ -257,6 +257,22 @@ module IsoDoc
         XML
       end
 
+      # ISO House Style: a status footnote (withdrawn/replaced, "available
+      # from", etc.) on a bibliography reference belongs on the document
+      # designation, not on the [n] ordinal. Place the footnote(s) after the
+      # SDO identifier rather than after the ordinal; non-standard references
+      # (no designation) are left as the base renders them.
+      # https://github.com/metanorma/iso-10303/issues/717
+      def biblio_ref_entry_code(ordinal, ids, _standard, datefn, _bib)
+        ret = esc(ids[:ordinal]) || esc(ids[:content]) || esc(ids[:metanorma]) ||
+          "[#{esc ordinal.to_s}]"
+        if ids[:sdo] && !ids[:sdo].empty?
+          "#{prefix_bracketed_ref(ret)}#{esc ids[:sdo]}#{datefn}, "
+        else
+          prefix_bracketed_ref("#{ret}#{datefn}")
+        end
+      end
+
       include Init
     end
   end

--- a/spec/isodoc/ref_spec.rb
+++ b/spec/isodoc/ref_spec.rb
@@ -661,10 +661,9 @@ RSpec.describe IsoDoc do
              <references normative="false" id="_" displayorder="2">
                 <fmt-title id="_" depth="1">Bibliography</fmt-title>
                 <bibitem id="b" type="standard" anchor="b">
-                <biblio-tag>[1]<fn id="_" reference="1" original-reference="_" target="_">
+                <biblio-tag>[1]<tab/><span class="stdpublisher">IETF RFC</span> <span class="stddocNumber">3394</span><fn id="_" reference="1" original-reference="_" target="_">
                   <p>Available at <span class="biburl"><fmt-link target="https://www.rfc-editor.org/info/rfc3394">https://www.rfc-editor.org/info/rfc3394</fmt-link></span></p>
-                  <fmt-fn-label><span class="fmt-caption-label"><sup><semx element="autonum" source="_">1</semx><span class="fmt-label-delim">)</span></sup></span></fmt-fn-label></fn>
-       <tab/><span class="stdpublisher">IETF RFC</span> <span class="stddocNumber">3394</span>, </biblio-tag>
+                  <fmt-fn-label><span class="fmt-caption-label"><sup><semx element="autonum" source="_">1</semx><span class="fmt-label-delim">)</span></sup></span></fmt-fn-label></fn>, </biblio-tag>
                <formattedref>J. SCHAAD and R. HOUSLEY. <em><span class="stddocTitle">Advanced Encryption Standard (AES) Key Wrap Algorithm</span></em>. RFC Series</formattedref>
                <fetched/>
                <title type="main" format="text/plain">Advanced Encryption Standard (AES) Key Wrap Algorithm</title>


### PR DESCRIPTION
Refs https://github.com/metanorma/iso-10303/issues/717

Per ISO House Style, a status footnote on a bibliography reference — withdrawn/replaced, "available from", etc. — belongs on the document **designation** (`ISO nnnn`), not on the `[n]` bibliography ordinal. The base `biblio_ref_entry_code` places `datefn` immediately after the ordinal.

This overrides `biblio_ref_entry_code` in the ISO presentation converter so the footnote(s) render **after the SDO identifier** (`[1]<tab/>ISO nnnn<fn>…`). Non-standard references (no designation) are left exactly as the base renders them.

Companion: metanorma/isodoc#815 (the raised footnote-ref underline). 

Verified against a standalone `IsoDoc::Iso::PresentationXMLConvert` run — output is `[1]<tab/>ISO 8000-2<fn>…`. The one affected `ref_spec.rb` expectation (IETF RFC 3394) is updated. Note: the isodoc spec suite could not be run locally right now because `lutaml/xmi`'s working release was yanked and the harness fails to load it; CI validates the expectations.

🤖
