### PR TITLE
degrade docidentifier errors to warnings under a taste stage repertoire

### DIFF
--- a/lib/metanorma/iso/front_id.rb
+++ b/lib/metanorma/iso/front_id.rb
@@ -169,6 +169,10 @@ module Metanorma
         iso_id_out_non_amd(xml, params, with_prf)
       rescue StandardError, *STAGE_ERROR => e
         @log.add("ISO_52", "Document identifier: #{e}")
+        # a taste layered on this flavour (:docstage-valid:) manages its
+        # own stage repertoire and docidentifier template: do not abort
+        # when pubid cannot parse a taste-supplied stage
+        @docstage_valid and return
         clean_abort("Document identifier: #{e}", xml)
       end
 

--- a/spec/metanorma/validate_spec.rb
+++ b/spec/metanorma/validate_spec.rb
@@ -65,6 +65,39 @@ RSpec.describe Metanorma::Iso, type: :validation do
       expect(illegal_stage_70).to include("Illegal document stage: 70.00")
       expect(legal_stage_60).not_to include("Illegal document stage: 60.00")
     end
+
+    it "degrades docidentifier errors to warnings when a taste supplies " \
+       "docstage-valid" do
+      input = <<~INPUT
+        = Document title
+        Author
+        :docfile: test.adoc
+        :nodoc:
+        :no-isobib:
+        :novalid:
+        :docnumber: 1000
+        :status: draft
+
+        text
+      INPUT
+      allow_any_instance_of(Metanorma::Iso::Converter)
+        .to receive(:iso_id_out_common)
+        .and_raise(StandardError.new("boom"))
+
+      # without a taste stage repertoire, identifier failure is fatal
+      expect { Asciidoctor.convert(input, *OPTIONS) }
+        .to raise_error(SystemExit)
+      FileUtils.rm_f "test.xml.abort"
+
+      # with one, it is logged (ISO_52) and the compile survives
+      expect do
+        Asciidoctor.convert(
+          input.sub(":status: draft",
+                    ":status: draft\n:docstage-valid: draft, published"),
+          *OPTIONS
+        )
+      end.not_to raise_error
+    end
   end
 
   context "Substage validation" do


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/24

Part of the taste stage-repertoire takeover: tastes validate input stages against their own repertoire and advertise the mapped base stages to the flavour as `:docstage-valid:`, which supersedes the flavour's recognised-stage list. Companion PRs in metanorma-standoc, metanorma-generic, metanorma-taste, isodoc, metanorma-ieee, metanorma-nist, metanorma-iso; release metanorma-standoc first, metanorma-taste last. Full narrative on the ticket.

🤖
