### PR TITLE
resync isostandard-amd.rng: restore loadable amendment schema

### DIFF
--- a/lib/metanorma/iso/isostandard-amd.rng
+++ b/lib/metanorma/iso/isostandard-amd.rng
@@ -39,7 +39,7 @@
         <ref name="preface"/>
         <ref name="sections"/>
         <optional>
-          <ref name="review-container"/>
+          <ref name="annotation-container"/>
         </optional>
       </element>
     </define>


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-iso/issues/513

Resync of the vendored amendment schema from metanorma-model-iso@bcade37: the review->annotation rename left `isostandard-amd.rng` referencing the deleted `review-container` pattern, so jing could not load the schema and amendment/technical-corrigendum documents had no effective grammar validation. With the schema loadable again, amendment documents surface real (previously masked) validation errors; those are census material for #513, not regressions from this change.

🤖
