### PR TITLE
Wrap subclause cross-reference titles in <semx element='title'>

### DIFF
--- a/lib/isodoc/iso/xref_section.rb
+++ b/lib/isodoc/iso/xref_section.rb
@@ -49,9 +49,11 @@ module IsoDoc
       def section_name_anchors_section(clause, num, level)
         xref = labelled_autonum(@labels["section"], num)
         label = labelled_autonum(@labels["section"], num)
+        t = clause_title(clause)
         @anchors[clause["id"]] =
           { label:, xref:, elem: @labels["section"],
-            title: clause_title(clause), level: level, type: "clause" }
+            title: t && semx(clause, t, "title"), level: level,
+            type: "clause" }
       end
 
       # subclauses are not prefixed with "Clause" but @labels["subclause"],
@@ -59,9 +61,10 @@ module IsoDoc
       # Retaining subtype for the semantics
       def section_name_anchors_subclause(clause, num, level)
         xref = labelled_autonum(@labels["subclause"], num)
+        t = subclause_title(clause)
         @anchors[clause["id"]] =
           { label: num, level: level, xref:, subtype: "clause",
-            title: subclause_title(clause), elem: @labels["subclause"] }
+            title: t && semx(clause, t, "title"), elem: @labels["subclause"] }
       end
 
       def annex_name_anchors1(clause, num, level)

--- a/spec/isodoc/xref_section_spec.rb
+++ b/spec/isodoc/xref_section_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe IsoDoc do
       <xref target="O" style="title" id="_"/>
       <semx element="xref" source="_">
          <fmt-xref target="O" style="title">
-            <span class="citesec">Title B</span>
+            <span class="citesec"><semx element="title" source="O">Title B</semx></span>
          </fmt-xref>
       </semx>
       <xref target="M1" style="title" id="_"/>
@@ -524,7 +524,7 @@ RSpec.describe IsoDoc do
             <xref target="O" style="title" id="_"/>
             <semx element="xref" source="_">
                <fmt-xref target="O" style="title">
-                  <span class="citesec">Title B</span>
+                  <span class="citesec"><semx element="title" source="O">Title B</semx></span>
                </fmt-xref>
             </semx>
             <xref target="M1" style="title" id="_"/>


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/68

Subclause cross-reference titles were stored **bare** on the anchor, where base isodoc stores them **semx-wrapped**. `anchor_xref_full` emits the anchor title verbatim, so `full`/`title`-style cross-references to subclauses dropped the `<semx element="title" source="…">` wrapper that top-level clauses keep — breaking downstream XSLT that keys off `semx[@element='title']`.

Wrap the title in `section_name_anchors_section` and `section_name_anchors_subclause`, matching base isodoc, guarded so title-less clauses stay `nil`. Two `citesec` fixtures updated to the wrapped form.

🤖
