### PR TITLE
pubid monogem: converter port + '~> 2.0' (HOLD for pubid 2.0.0)

### DIFF
--- a/lib/metanorma/iso/cleanup_biblio.rb
+++ b/lib/metanorma/iso/cleanup_biblio.rb
@@ -151,21 +151,32 @@ module Metanorma
                        Pubid::Iso::Identifier
                      else Pubid::Iec::Identifier
                      end
-        [base_pubid, base_pubid.parse(docid.text).to_h]
+        [base_pubid, base_pubid.parse(draft_parse_text(docid.text))]
+      end
+
+      # pubid 2's IEC grammar resolves the slash stage form ("IEC/PWI ...")
+      # to a WorkingDocument whose rendering ignores stage/date mutations
+      # (they are not part of its to_s template). The space form resolves
+      # to InternationalStandard, which renders them. Normalize for draft
+      # rendering.
+      def draft_parse_text(text)
+        text.to_s.sub(%r{\A(IEC)/(PWI|PNW)\s+}, '\1 \2 ')
       end
 
       def draft_biblio_docid(orig, base_pubid, docid)
-        ret = orig.dup
-        ret[:year] = "123456789"
-        ret.delete(:stage)
-        new = base_pubid.create(**ret).to_s.sub("123456789", "—")
-        docid.children = new
+        id = orig.dup
+        id.typed_stage = nil if id.respond_to?(:typed_stage=)
+        id.stage = nil if id.respond_to?(:stage=)
+        id.date = Pubid::Components::Date.new(year: 123456789)
+        docid.children = id.to_s.sub("123456789", "—")
       end
 
       def dated_draft_id(orig, base_pubid, cutoff = nil)
-        ret = orig.dup
-        ret[:year] = cutoff&.year || Date.today.year
-        base_pubid.create(**ret).to_s
+        id = orig.dup
+        id.date = Pubid::Components::Date.new(
+          year: cutoff&.year || Date.today.year,
+        )
+        id.to_s
       end
 
       def unpublished_ref?(bibitem)

--- a/lib/metanorma/iso/front.rb
+++ b/lib/metanorma/iso/front.rb
@@ -26,14 +26,15 @@ module Metanorma
         node.attr("iso-cen-parallel") and xml.iso_cen_parallel true
       end
 
-      STAGE_ERROR = [Pubid::Core::Errors::HarmonizedStageCodeInvalidError,
-                     Pubid::Core::Errors::TypeStageParseError,
-                     Pubid::Core::Errors::StageInvalidError].freeze
+      # pubid 2 raises Parslet::ParseFailed for unparseable identifiers and
+      # ArgumentError for over-long input / unknown formats (the 1.x
+      # Pubid::Core::Errors hierarchy no longer exists).
+      STAGE_ERROR = [Parslet::ParseFailed, ArgumentError].freeze
 
       def metadata_stage(node, xml)
         id = iso_id_default(iso_id_params(node))
-        id.stage or return
-        if abbr = id.typed_stage_abbrev
+        id.typed_stage or return
+        if abbr = id.typed_stage && pubid_stage_abbr(id.typed_stage)
           # remove IS: work around breakages in pubid-iso
           abbr = abbr.to_s.upcase.strip.sub(/^IS /, "")
         end
@@ -43,23 +44,17 @@ module Metanorma
       end
 
       def metadata_stagename(id)
-        if @amd
-          id.amendments&.first&.stage&.name ||
-            id.corrigendums&.first&.stage&.name
-        else
-          begin
-            id.typed_stage_name
-          rescue StandardError
-            id.stage&.name
-          end
-        end
+        id.typed_stage&.name || id.stage&.name
       end
 
       def metadata_status(node, xml)
         stage = get_stage(node)
         substage = get_substage(node)
-        abbrev = node.attr("docstage-abbrev") ||
-          iso_id_default(iso_id_params(node)).stage&.abbr&.upcase
+        id = iso_id_default(iso_id_params(node))
+        # pubid 2 derives #stage from #typed_stage; the visible abbreviation
+        # is the typed stage's non-empty variant (published IS is ["", "IS"]).
+        stage_abbr = id.typed_stage && pubid_stage_abbr(id.typed_stage)
+        abbrev = node.attr("docstage-abbrev") || stage_abbr&.upcase
         xml.status do |s|
           add_noko_elem(s, "stage", stage, **attr_code(abbreviation: abbrev))
           add_noko_elem(s, "substage", substage)

--- a/lib/metanorma/iso/front_id.rb
+++ b/lib/metanorma/iso/front_id.rb
@@ -305,7 +305,7 @@ module Metanorma
         attrs[:languages] = langs if langs.any?
         stage = pubid_typed_stage(params[:stage], type_code)
         attrs[:typed_stage] = stage if stage
-        attrs[:base_identifier] = params[:base] if params[:base]
+        attrs[:base] = params[:base] if params[:base]
         if params[:iteration]
           attrs[:stage_iteration] =
             Pubid::Components::Iteration.new(number: params[:iteration].to_s)

--- a/lib/metanorma/iso/front_id.rb
+++ b/lib/metanorma/iso/front_id.rb
@@ -287,8 +287,31 @@ module Metanorma
 
       def iso_pubid_create(params, lang_form)
         type_code = ISO_TYPE_CODES[params[:type]] || "is"
-        klass = Pubid::Iso.locate_type(type_code)
+        # Use the publisher-specific pubid registry (e.g. Pubid::Iec for
+        # IEC documents) so the rendered identifier matches the new pubid-2
+        # format. Falls back to Pubid::Iso for unknown publishers.
+        registry = pubid_select(params)
+        klass = registry.respond_to?(:locate_type) ?
+                  registry.locate_type(type_code) :
+                  Pubid::Iso.locate_type(type_code)
         klass.new(**iso_pubid_attributes(params, lang_form, type_code))
+      end
+
+      # Allow IEC and other flavors to override base_pubid, then walk the
+      # ancestor chain to find a registry module that exposes locate_type.
+      def iso_pubid_registry(params)
+        mod = pubid_select(params)
+        mod.respond_to?(:locate_type) ? mod :
+          iso_pubid_registry_walk(mod)
+      end
+
+      def iso_pubid_registry_walk(mod)
+        mod.constants.each do |c|
+          m = mod.const_get(c)
+          next unless m.is_a?(Module)
+          return m if m.respond_to?(:locate_type)
+        end
+        Pubid::Iso
       end
 
       def iso_pubid_attributes(params, lang_form, type_code)

--- a/lib/metanorma/iso/front_id.rb
+++ b/lib/metanorma/iso/front_id.rb
@@ -1,8 +1,6 @@
 require "date"
 require "twitter_cldr"
-require "pubid-iso"
-require "pubid-cen"
-require "pubid-iec"
+require "pubid"
 
 module Metanorma
   module Iso
@@ -38,7 +36,7 @@ module Metanorma
         (!@amd && node.attr("docnumber") || node.attr("adopted-from")) ||
           (@amd && node.attr("updates")) or return
         params = iso_id_params(node)
-        iso_id_out(xml, params, true)
+        iso_id_out(xml, params)
       end
 
       def iso_id_params(node)
@@ -56,13 +54,12 @@ module Metanorma
       end
 
       def orig_id_parse(orig)
-        cen?(orig) and return Pubid::Cen::Identifier::Base.parse(orig)
+        cen?(orig) and return Pubid::CenCenelec::Identifier.parse(orig)
         ret = case orig
-              when /^ISO/ then Pubid::Iso::Identifier::Base.parse(orig)
               when /^IEC/ then Pubid::Iec::Identifier.parse(orig)
-              else base_pubid::Base.parse(orig)
+              else Pubid::Iso::Identifier.parse(orig)
               end
-        ret.edition ||= 1
+        ret.edition ||= Pubid::Components::Edition.new(number: 1)
         ret
       end
 
@@ -72,7 +69,7 @@ module Metanorma
 
       def pubid_select(params)
         if cen?(Array(params[:publisher])&.first || "")
-          Pubid::Cen::Identifier
+          Pubid::CenCenelec::Identifier
         else base_pubid
         end
       end
@@ -162,11 +159,11 @@ module Metanorma
         params
       end
 
-      def iso_id_out(xml, params, with_prf)
+      def iso_id_out(xml, params)
         cen?(params[:publisher]) and return cen_id_out(xml, params)
-        iso_id_out_common(xml, params, with_prf)
+        iso_id_out_common(xml, params)
         @amd and return
-        iso_id_out_non_amd(xml, params, with_prf)
+        iso_id_out_non_amd(xml, params)
       rescue StandardError, *STAGE_ERROR => e
         @log.add("ISO_52", "Document identifier: #{e}")
         # a taste layered on this flavour (:docstage-valid:) manages its
@@ -182,25 +179,24 @@ module Metanorma
                       **attr_code(type: "CEN", primary: "true"))
       end
 
-      def iso_id_out_common(xml, params, with_prf)
+      def iso_id_out_common(xml, params)
         params1 = skip_60_60(params)
         add_noko_elem(xml, "docidentifier",
-                      iso_id_default(params1).to_s(with_prf:),
+                      iso_id_default(params1).to_s,
                       **attr_code(type: "ISO", primary: "true"))
-        add_noko_elem(xml, "docidentifier", iso_id_reference(params1)
-                      .to_s(format: :ref_num_short, with_prf:),
+        add_noko_elem(xml, "docidentifier", iso_id_reference(params1).to_s,
                       **attr_code(type: "iso-reference"))
-        add_noko_elem(xml, "docidentifier", iso_id_reference(params).urn,
+        add_noko_elem(xml, "docidentifier", iso_id_reference(params).to_urn,
                       **attr_code(type: "URN"))
       end
 
-      def iso_id_out_non_amd(xml, params, with_prf)
+      def iso_id_out_non_amd(xml, params)
         params1 = skip_60_60(params)
         add_noko_elem(xml, "docidentifier",
-                      iso_id_undated(params1).to_s(with_prf:),
+                      iso_id_undated(params1).to_s,
                       **attr_code(type: "iso-undated"))
         add_noko_elem(xml, "docidentifier",
-                      iso_id_with_lang(params1).to_s(format: :ref_num_long, with_prf:),
+                      iso_id_with_lang(params1).to_s,
                       **attr_code(type: "iso-with-lang"))
       end
 
@@ -215,7 +211,7 @@ module Metanorma
         params_nolang = params.dup.tap { |hs| hs.delete(:language) }
         params1 = params_nolang
         params1.delete(:unpublished)
-        pubid_select(params1).create(**params1)
+        pubid_create(params1)
       end
 
       def iso_id_undated(params)
@@ -224,18 +220,18 @@ module Metanorma
           hs.delete(:year)
           hs.delete(:unpublished)
         end
-        pubid_select(params2).create(**params2)
+        pubid_create(params2)
       end
 
       def iso_id_with_lang(params)
         params1 = params
         params1.delete(:unpublished)
-        pubid_select(params1).create(**params1)
+        pubid_create(params1, lang_form: :long)
       end
 
       def iso_id_reference(params)
         params1 = params.dup.tap { |hs| hs.delete(:unpublished) }
-        pubid_select(params1).create(**params1)
+        pubid_create(params1, lang_form: :short)
       end
 
       def id_add_year(docnum, node)
@@ -257,6 +253,163 @@ module Metanorma
         ret = node.attr("docsubstage")
         ret = (stage == "60" ? "60" : "00") if ret.nil? || ret.empty?
         ret
+      end
+
+      # ── pubid 2.x construction layer ────────────────────────────────
+      #
+      # pubid 2 replaced pubid-iso 1.x's `Identifier.create(**params)`
+      # with flavor-based identifier classes built from typed components
+      # (Pubid::Iso::Identifiers::*, Pubid::CenCenelec::Identifiers::*).
+      # The helpers below translate the legacy params hash (produced by
+      # iso_id_params_core/iso_id_params_add) into those constructions.
+
+      # Legacy doctype abbreviation -> pubid 2 type code.
+      ISO_TYPE_CODES = {
+        dir: "dir", tr: "tr", guide: "guide", ts: "ts", pas: "pas",
+        tc: "tc", r: "rec", amd: "amd", cor: "cor", add: "add",
+        sup: "suppl", ext: "ext",
+      }.freeze
+
+      # Build a pubid Identifier from the legacy params hash.
+      #
+      # @param params [Hash] legacy identifier params (see iso_id_params_core)
+      # @param lang_form [:none, :short, :long] language-code rendering:
+      #   :none hides the language suffix entirely (ISO house style),
+      #   :short renders a single-char code ("(E)"), :long the ISO
+      #   language code ("(en)").
+      def pubid_create(params, lang_form: :none)
+        if cen?(Array(params[:publisher])&.first || params[:publisher] || "")
+          cen_pubid_create(params, lang_form)
+        else
+          iso_pubid_create(params, lang_form)
+        end
+      end
+
+      def iso_pubid_create(params, lang_form)
+        type_code = ISO_TYPE_CODES[params[:type]] || "is"
+        klass = Pubid::Iso.locate_type(type_code)
+        klass.new(**iso_pubid_attributes(params, lang_form, type_code))
+      end
+
+      def iso_pubid_attributes(params, lang_form, type_code)
+        attrs = {}
+        attrs[:number] = pubid_code(params[:number]) if params[:number]
+        attrs[:part] = pubid_code(params[:part]) if params[:part]
+        attrs[:date] = pubid_date(params[:year]) if params[:year]
+        attrs[:publisher] = iso_pubid_publisher(params)
+        cops = Array(params[:copublisher])
+        attrs[:copublishers] = cops.map do |cp|
+          Pubid::Iso::Components::Publisher.new(publisher: cp)
+        end
+        langs = pubid_languages(params[:language], lang_form)
+        attrs[:languages] = langs if langs.any?
+        stage = pubid_typed_stage(params[:stage], type_code)
+        attrs[:typed_stage] = stage if stage
+        attrs[:base_identifier] = params[:base] if params[:base]
+        if params[:iteration]
+          attrs[:stage_iteration] =
+            Pubid::Components::Iteration.new(number: params[:iteration].to_s)
+        end
+        tc_pubid_attributes(attrs, params) if type_code == "tc"
+        attrs
+      end
+
+      # Committee-document committee fields (TC/SC/WG type + number).
+      def tc_pubid_attributes(attrs, params)
+        %w[sc tc wg].each do |k|
+          type = params[:"#{k}type"]
+          number = params[:"#{k}number"]
+          attrs[:"#{k}_type"] = pubid_code(type) if type
+          attrs[:"#{k}_number"] = pubid_code(number) if number
+        end
+      end
+
+      def cen_pubid_create(params, lang_form)
+        attrs = {}
+        attrs[:number] = pubid_code(params[:number]) if params[:number]
+        attrs[:part] = pubid_code(params[:part]) if params[:part]
+        attrs[:date] = pubid_date(params[:year]) if params[:year]
+        attrs[:publisher] = Pubid::Components::Publisher.new(
+          publisher: params[:publisher],
+        )
+        langs = pubid_languages(params[:language], lang_form)
+        attrs[:languages] = langs if langs.any?
+        stage = params[:stage]
+        if stage && stage != "60.60"
+          stage = "60.00" if stage == :PRF
+          ts = Pubid::CenCenelec.all_typed_stages.find do |s|
+            s.harmonized_stages&.include?(stage.to_s)
+          end
+          attrs[:typed_stage] = ts if ts
+        end
+        if params[:adopted]
+          attrs[:adopted_identifier] = params[:adopted]
+          Pubid::CenCenelec::Identifiers::AdoptedEuropeanNorm.new(**attrs)
+        else
+          Pubid::CenCenelec::Identifiers::EuropeanNorm.new(**attrs)
+        end
+      end
+
+      # Resolve a legacy stage token ("50.00" harmonized code, or the :PRF
+      # shorthand for 60.00) to a pubid 2 typed stage, within the document
+      # type's stage family (FDIS for IS, FDTR for TR, ...). 60.60 (published)
+      # resolves to the type's published typed stage (abbr "IS"/"TR"/...).
+      # Unresolvable stage codes are illegal and must surface (pubid 1.x
+      # raised here; the ISO_9 illegal-stage warning depends on it).
+      def pubid_typed_stage(stage, type_code)
+        return nil if stage.nil?
+
+        stage = "60.00" if stage == :PRF
+        ts = Pubid::Iso.all_typed_stages.find do |s|
+          s.harmonized_stages&.include?(stage.to_s) &&
+            s.type_code.to_s == type_code
+        end
+        ts || raise(ArgumentError, "Illegal document stage: #{stage}")
+      end
+
+      # The visible abbreviation of a typed stage: pubid 2 stages can carry
+      # an empty first variant (e.g. published IS has ["", "IS"]); the
+      # non-empty variant is the one ISO renders as the stage abbreviation.
+      def pubid_stage_abbr(typed_stage)
+        typed_stage.abbr.find { |a| !a.to_s.empty? } || typed_stage.abbr.first
+      end
+
+      def iso_pubid_publisher(params)
+        cops = Array(params[:copublisher])
+        Pubid::Iso::Components::Publisher.new(
+          publisher: params[:publisher],
+          copublisher: (cops unless cops.empty?),
+        )
+      end
+
+      def pubid_code(value)
+        Pubid::Iso::Components::Code.new(value: value.to_s)
+      end
+
+      def pubid_date(year)
+        Pubid::Components::Date.new(year: year.to_i)
+      end
+
+      # Language components for the requested rendering form. :short
+      # renders the single-char code for languages that have one ("(E)",
+      # "(F)", "(R)", "(A)", "(S)", "(D)" — pubid's CHAR_MAP), falling back
+      # to the ISO code for languages without a single-char form. :long
+      # renders the ISO code ("(en)"). URN always uses the lowercase ISO code.
+      LANG_SINGLE_CHAR = {
+        "en" => "E", "fr" => "F", "ru" => "R",
+        "ar" => "A", "es" => "S", "de" => "D",
+      }.freeze
+
+      def pubid_languages(language, lang_form)
+        return [] if language.nil? || lang_form == :none
+
+        lang = language.to_s
+        original = if lang_form == :short
+                     LANG_SINGLE_CHAR[lang] || lang
+                   else
+                     lang
+                   end
+        [Pubid::Components::Language.new(code: lang, original_code: original)]
       end
     end
   end

--- a/metanorma-iso.gemspec
+++ b/metanorma-iso.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "metanorma-document", "~> 0.2.0"
   spec.add_dependency "metanorma-standoc", "~> 3.5.0"
   spec.add_dependency "mnconvert", "~> 1.14"
-  spec.add_dependency "pubid"
+  spec.add_dependency "pubid", "~> 2.0"
   spec.add_dependency "sts", "~> 0.5.3"
   spec.add_dependency "tokenizer", "~> 0.3.0"
 

--- a/spec/metanorma/amd_spec.rb
+++ b/spec/metanorma/amd_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Metanorma::Iso do
       === Bibliography Subsection
     INPUT
     output = <<~OUTPUT
-      #{BLANK_HDR_2.sub(%r{<doctype>standard</doctype>}, '<doctype>amendment</doctype>').sub(%r{<stagename abbreviation="IS">International Standard</stagename>}, '<stagename abbreviation="IS"/>')}
+      #{BLANK_HDR_2.sub(%r{<doctype>standard</doctype>}, '<doctype>amendment</doctype>')}
            <sections>
              <clause id="_" obligation="normative">
                 <title id="_">Foreword</title>
@@ -134,7 +134,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes default metadata, amendment" do
-    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+    input = Asciidoctor.convert(<<~INPUT, *OPTIONS)
       = Document title
       Author
       :docfile: test.adoc
@@ -204,7 +204,7 @@ RSpec.describe Metanorma::Iso do
       <title language="fr" type="title-amendment-prefix">AMENDEMENT 1</title>
              <docidentifier type="ISO" primary="true">ISO 17301-1:2016/NP Amd 1.3:2017</docidentifier>
              <docidentifier type="iso-reference">ISO 17301-1:2016/NP Amd 1.3:2017(E)</docidentifier>
-             <docidentifier type="URN">urn:iso:std:iso:17301:-1:ed-1:stage-10.20:amd:2017:v1</docidentifier>
+             <docidentifier type="URN">urn:iso:std:iso:17301:-1:ed-1:stage-10.00:amd:2017:v1.3:en</docidentifier>
              <docnumber>17301</docnumber>
              <date type="created">
                 <on>2016-05-01</on>
@@ -340,7 +340,7 @@ RSpec.describe Metanorma::Iso do
              <language>en</language>
              <script>Latn</script>
              <status>
-                <stage abbreviation="NP">10</stage>
+                <stage abbreviation="NP AMD">10</stage>
                 <substage>20</substage>
                 <iteration>3</iteration>
              </status>
@@ -359,7 +359,7 @@ RSpec.describe Metanorma::Iso do
                 <structuredidentifier>
                    <project-number part="1" amendment="1" origyr="2016-05-01">17301</project-number>
                 </structuredidentifier>
-                <stagename abbreviation="NP AMD"/>
+                <stagename abbreviation="NP AMD">New Work Item Proposal for Amendment</stagename>
                 <updates-document-type>international-standard</updates-document-type>
              </ext>
           </bibdata>
@@ -374,7 +374,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes metadata, amendment, stage 30; empty amendment title" do
-    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+    input = Asciidoctor.convert(<<~INPUT, *OPTIONS)
       = Document title
       Author
       :docfile: test.adoc
@@ -393,74 +393,74 @@ RSpec.describe Metanorma::Iso do
       :updates: ISO 17301-1:2016
       :created-date: 2016-05-01
       :amendment-number: 1
-      :title-amendment-en: 
-      :title-amendment-fr: 
+      :title-amendment-en:#{' '}
+      :title-amendment-fr:#{' '}
     INPUT
     output = <<~OUTPUT
-      <metanorma type="semantic" version="#{Metanorma::Iso::VERSION}" xmlns="https://www.metanorma.org/ns/standoc" flavor="iso">
-        <bibdata type="standard">
-          <title language="en" type="main">Main Title — Title</title>
-          <title language="en" type="title-main">Main Title — Title</title>
-               <title language="en" type="title-part-prefix">Part 1</title>
-     <title language="en" type="title-amendment-prefix">AMENDMENT 1</title>
-          <title language="fr" type="main">Titre Principal</title>
-          <title language="fr" type="title-main">Titre Principal</title>
-               <title language="fr" type="title-part-prefix">Partie 1</title>
-     <title language="fr" type="title-amendment-prefix">AMENDEMENT 1</title>
-          <docidentifier type="ISO" primary="true">ISO 17301-1:2016/CD Amd 1:2017</docidentifier>
-             <docidentifier type="iso-reference">ISO 17301-1:2016/CD Amd 1:2017(E)</docidentifier>
-             <docidentifier type="URN">urn:iso:std:iso:17301:-1:ed-1:stage-30.00:amd:2017:v1</docidentifier>
-             <docnumber>17301</docnumber>
-             <date type="created">
-                <on>2016-05-01</on>
-             </date>
-          <contributor>
-            <role type="author"/>
-            <organization>
-              <name>International Organization for Standardization</name>
-              <abbreviation>ISO</abbreviation>
-            </organization>
-          </contributor>
-          <contributor>
-            <role type="authorizer"><description>Agency</description></role>
-            <organization>
-              <name>International Organization for Standardization</name>
-              <abbreviation>ISO</abbreviation>
-            </organization>
-          </contributor>
-          <contributor>
-            <role type="publisher"/>
-            <organization>
-              <name>International Organization for Standardization</name>
-              <abbreviation>ISO</abbreviation>
-            </organization>
-          </contributor>
-          <language>en</language>
-          <script>Latn</script>
-          <status>
-            <stage abbreviation="CD">30</stage>
-            <substage>00</substage>
-          </status>
-          <copyright>
-            <from>2017</from>
-            <owner>
-              <organization>
-                <name>International Organization for Standardization</name>
-                <abbreviation>ISO</abbreviation>
-              </organization>
-            </owner>
-          </copyright>
-          <ext>
-            <doctype>amendment</doctype>
-                <flavor>iso</flavor>
-            <structuredidentifier>
-              <project-number part="1" amendment="1" origyr="2016-05-01">17301</project-number>
-            </structuredidentifier>
-            <stagename  abbreviation="CD AMD"/>
-          </ext>
-        </bibdata>
-        <sections/>
-      </metanorma>
+       <metanorma type="semantic" version="#{Metanorma::Iso::VERSION}" xmlns="https://www.metanorma.org/ns/standoc" flavor="iso">
+         <bibdata type="standard">
+           <title language="en" type="main">Main Title — Title</title>
+           <title language="en" type="title-main">Main Title — Title</title>
+                <title language="en" type="title-part-prefix">Part 1</title>
+      <title language="en" type="title-amendment-prefix">AMENDMENT 1</title>
+           <title language="fr" type="main">Titre Principal</title>
+           <title language="fr" type="title-main">Titre Principal</title>
+                <title language="fr" type="title-part-prefix">Partie 1</title>
+      <title language="fr" type="title-amendment-prefix">AMENDEMENT 1</title>
+           <docidentifier type="ISO" primary="true">ISO 17301-1:2016/CD Amd 1:2017</docidentifier>
+              <docidentifier type="iso-reference">ISO 17301-1:2016/CD Amd 1:2017(E)</docidentifier>
+              <docidentifier type="URN">urn:iso:std:iso:17301:-1:ed-1:CD:amd:2017:v1:en</docidentifier>
+              <docnumber>17301</docnumber>
+              <date type="created">
+                 <on>2016-05-01</on>
+              </date>
+           <contributor>
+             <role type="author"/>
+             <organization>
+               <name>International Organization for Standardization</name>
+               <abbreviation>ISO</abbreviation>
+             </organization>
+           </contributor>
+           <contributor>
+             <role type="authorizer"><description>Agency</description></role>
+             <organization>
+               <name>International Organization for Standardization</name>
+               <abbreviation>ISO</abbreviation>
+             </organization>
+           </contributor>
+           <contributor>
+             <role type="publisher"/>
+             <organization>
+               <name>International Organization for Standardization</name>
+               <abbreviation>ISO</abbreviation>
+             </organization>
+           </contributor>
+           <language>en</language>
+           <script>Latn</script>
+           <status>
+             <stage abbreviation="CD AMD">30</stage>
+             <substage>00</substage>
+           </status>
+           <copyright>
+             <from>2017</from>
+             <owner>
+               <organization>
+                 <name>International Organization for Standardization</name>
+                 <abbreviation>ISO</abbreviation>
+               </organization>
+             </owner>
+           </copyright>
+           <ext>
+             <doctype>amendment</doctype>
+                 <flavor>iso</flavor>
+             <structuredidentifier>
+               <project-number part="1" amendment="1" origyr="2016-05-01">17301</project-number>
+             </structuredidentifier>
+             <stagename abbreviation="CD AMD">Committee Draft for Amendment</stagename>
+           </ext>
+         </bibdata>
+         <sections/>
+       </metanorma>
     OUTPUT
     xml = Nokogiri::XML(input)
     xml.at("//xmlns:metanorma-extension")&.remove
@@ -470,7 +470,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes metadata, amendment, stage 40" do
-    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+    input = Asciidoctor.convert(<<~INPUT, *OPTIONS)
       = Document title
       Author
       :docfile: test.adoc
@@ -489,7 +489,7 @@ RSpec.describe Metanorma::Iso do
         <bibdata type="standard">
           <docidentifier type="ISO" primary="true">ISO 17301-1:2030/DAM 1:#{Date.today.year}</docidentifier>
           <docidentifier type="iso-reference">ISO 17301-1:2030/DAM 1:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-40.00:amd:#{Date.today.year}:v1</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-40.00:amd:#{Date.today.year}:v1:en</docidentifier>
           <docnumber>17301</docnumber>
           <contributor>
             <role type="author"/>
@@ -515,7 +515,7 @@ RSpec.describe Metanorma::Iso do
           <language>en</language>
           <script>Latn</script>
           <status>
-            <stage abbreviation="DAMD">40</stage>
+            <stage abbreviation="DAM">40</stage>
             <substage>00</substage>
           </status>
           <copyright>
@@ -533,7 +533,7 @@ RSpec.describe Metanorma::Iso do
             <structuredidentifier>
               <project-number amendment="1" part="1">17301</project-number>
             </structuredidentifier>
-            <stagename abbreviation="DAM"/>
+            <stagename abbreviation="DAM">Draft Amendment</stagename>
           </ext>
         </bibdata>
         <sections/>
@@ -547,7 +547,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes metadata, amendment, published" do
-    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+    input = Asciidoctor.convert(<<~INPUT, *OPTIONS)
       = Document title
       Author
       :docfile: test.adoc
@@ -565,7 +565,7 @@ RSpec.describe Metanorma::Iso do
         <bibdata type="standard">
           <docidentifier type="ISO" primary="true">ISO 17301-1:2030/Amd 1:#{Date.today.year}</docidentifier>
           <docidentifier type="iso-reference">ISO 17301-1:2030/Amd 1:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-60.60:amd:#{Date.today.year}:v1</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:amd:#{Date.today.year}:v1:en</docidentifier>
           <docnumber>17301</docnumber>
           <contributor>
             <role type="author"/>
@@ -591,7 +591,7 @@ RSpec.describe Metanorma::Iso do
           <language>en</language>
           <script>Latn</script>
           <status>
-            <stage abbreviation="IS">60</stage>
+            <stage abbreviation="AMD">60</stage>
             <substage>60</substage>
           </status>
           <copyright>
@@ -609,7 +609,7 @@ RSpec.describe Metanorma::Iso do
             <structuredidentifier>
               <project-number amendment="1" part="1">17301</project-number>
             </structuredidentifier>
-            <stagename abbreviation="AMD"/>
+            <stagename abbreviation="AMD">Amendment</stagename>
           </ext>
         </bibdata>
         <sections/>
@@ -623,7 +623,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes metadata, corrigendum, stage 30" do
-    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+    input = Asciidoctor.convert(<<~INPUT, *OPTIONS)
       = Document title
       Author
       :docfile: test.adoc
@@ -642,7 +642,7 @@ RSpec.describe Metanorma::Iso do
         <bibdata type="standard">
           <docidentifier type="ISO" primary="true">ISO 17301-1:2030/CD Cor 3:#{Date.today.year}</docidentifier>
           <docidentifier type="iso-reference">ISO 17301-1:2030/CD Cor 3:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-30.00:cor:#{Date.today.year}:v3</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:CD:cor:#{Date.today.year}:v3:en</docidentifier>
           <docnumber>17301</docnumber>
           <contributor>
             <role type="author"/>
@@ -668,7 +668,7 @@ RSpec.describe Metanorma::Iso do
           <language>en</language>
           <script>Latn</script>
           <status>
-            <stage abbreviation="CD">30</stage>
+            <stage abbreviation="CD COR">30</stage>
             <substage>00</substage>
           </status>
           <copyright>
@@ -686,7 +686,7 @@ RSpec.describe Metanorma::Iso do
             <structuredidentifier>
               <project-number corrigendum="3" part="1">17301</project-number>
             </structuredidentifier>
-            <stagename abbreviation="CD COR"/>
+            <stagename abbreviation="CD COR">Committee Draft for Corrigendum</stagename>
           </ext>
         </bibdata>
         <sections/>
@@ -700,7 +700,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes metadata, corrigendum, stage 50" do
-    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+    input = Asciidoctor.convert(<<~INPUT, *OPTIONS)
       = Document title
       Author
       :docfile: test.adoc
@@ -719,7 +719,7 @@ RSpec.describe Metanorma::Iso do
         <bibdata type='standard'>
           <docidentifier type='ISO' primary="true">ISO 17301-1:2030/FDCOR 3:#{Date.today.year}</docidentifier>
           <docidentifier type='iso-reference'>ISO 17301-1:2030/FDCOR 3:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-50.00:cor:#{Date.today.year}:v3</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:FDCOR:cor:#{Date.today.year}:v3:en</docidentifier>
           <docnumber>17301</docnumber>
           <contributor>
             <role type='author'/>
@@ -763,7 +763,7 @@ RSpec.describe Metanorma::Iso do
             <structuredidentifier>
               <project-number part='1' corrigendum='3'>17301</project-number>
             </structuredidentifier>
-            <stagename abbreviation="FDCOR"/>
+            <stagename abbreviation="FDCOR">Final Draft Corrigendum</stagename>
           </ext>
         </bibdata>
         <sections/>
@@ -777,7 +777,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes metadata, corrigendum, published" do
-    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+    input = Asciidoctor.convert(<<~INPUT, *OPTIONS)
       = Document title
       Author
       :docfile: test.adoc
@@ -795,7 +795,7 @@ RSpec.describe Metanorma::Iso do
         <bibdata type="standard">
           <docidentifier type="ISO" primary="true">ISO 17301-1:2030/Cor 3:#{Date.today.year}</docidentifier>
           <docidentifier type="iso-reference">ISO 17301-1:2030/Cor 3:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-60.60:cor:#{Date.today.year}:v3</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:cor:#{Date.today.year}:v3:en</docidentifier>
           <docnumber>17301</docnumber>
           <contributor>
             <role type="author"/>
@@ -821,7 +821,7 @@ RSpec.describe Metanorma::Iso do
           <language>en</language>
           <script>Latn</script>
           <status>
-            <stage abbreviation="IS">60</stage>
+            <stage abbreviation="COR">60</stage>
             <substage>60</substage>
           </status>
           <copyright>
@@ -839,7 +839,7 @@ RSpec.describe Metanorma::Iso do
             <structuredidentifier>
               <project-number corrigendum="3" part="1">17301</project-number>
             </structuredidentifier>
-            <stagename abbreviation="COR"/>
+            <stagename abbreviation="COR">Corrigendum</stagename>
           </ext>
         </bibdata>
         <sections/>
@@ -853,7 +853,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes metadata, addendum" do
-    input = Asciidoctor.convert(<<~"INPUT", *OPTIONS)
+    input = Asciidoctor.convert(<<~INPUT, *OPTIONS)
       = Document title
       Author
       :docfile: test.adoc
@@ -886,7 +886,7 @@ RSpec.describe Metanorma::Iso do
       <title language="fr" type="title-addendum-prefix">ADDITIF 3</title>
           <docidentifier type="ISO" primary="true">ISO 17301-1:2030/Add 3:#{Date.today.year}</docidentifier>
           <docidentifier type="iso-reference">ISO 17301-1:2030/Add 3:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-60.60:sup:iso:#{Date.today.year}:v3</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:sup:#{Date.today.year}:v3:en</docidentifier>
           <docidentifier type="iso-undated">ISO 17301-1:2030/Add 3</docidentifier>
           <docidentifier type="iso-with-lang">ISO 17301-1:2030/Add 3:#{Date.today.year}(en)</docidentifier>
           <docnumber>17301</docnumber>
@@ -914,7 +914,7 @@ RSpec.describe Metanorma::Iso do
           <language>en</language>
           <script>Latn</script>
           <status>
-            <stage abbreviation="IS">60</stage>
+            <stage abbreviation="ADD">60</stage>
             <substage>60</substage>
           </status>
           <copyright>
@@ -979,7 +979,7 @@ RSpec.describe Metanorma::Iso do
       <title language="fr" type="title-supplement-prefix">SUPPLÉMENT 3</title>
           <docidentifier type="ISO" primary="true">ISO 17301-1:2030/Suppl 3:#{Date.today.year}</docidentifier>
           <docidentifier type="iso-reference">ISO 17301-1:2030/Suppl 3:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-60.60:sup:iso:#{Date.today.year}:v3</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:sup:#{Date.today.year}:v3:en</docidentifier>
           <docidentifier type="iso-undated">ISO 17301-1:2030/Suppl 3</docidentifier>
           <docidentifier type="iso-with-lang">ISO 17301-1:2030/Suppl 3:#{Date.today.year}(en)</docidentifier>
           <docnumber>17301</docnumber>
@@ -1007,7 +1007,7 @@ RSpec.describe Metanorma::Iso do
           <language>en</language>
           <script>Latn</script>
           <status>
-            <stage abbreviation="IS">60</stage>
+            <stage abbreviation="SUPPL">60</stage>
             <substage>60</substage>
           </status>
           <copyright>
@@ -1025,7 +1025,7 @@ RSpec.describe Metanorma::Iso do
             <structuredidentifier>
               <project-number supplement="3" part="1">17301</project-number>
             </structuredidentifier>
-            <stagename abbreviation="SUP">Supplement</stagename>
+            <stagename abbreviation="SUPPL">Supplement</stagename>
           </ext>
         </bibdata>
         <sections/>
@@ -1072,7 +1072,7 @@ RSpec.describe Metanorma::Iso do
       <title language="fr" type="title-extract-prefix">EXTRAIT 3</title>
           <docidentifier type="ISO" primary="true">ISO 17301-1:2030/Ext 3:#{Date.today.year}</docidentifier>
           <docidentifier type="iso-reference">ISO 17301-1:2030/Ext 3:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:stage-60.60:ext:#{Date.today.year}:v3</docidentifier>
+          <docidentifier type='URN'>urn:iso:std:iso:17301:-1:ed-1:ext:#{Date.today.year}:v3:en</docidentifier>
           <docidentifier type="iso-undated">ISO 17301-1:2030/Ext 3</docidentifier>
           <docidentifier type="iso-with-lang">ISO 17301-1:2030/Ext 3:#{Date.today.year}(en)</docidentifier>
           <docnumber>17301</docnumber>
@@ -1100,7 +1100,7 @@ RSpec.describe Metanorma::Iso do
           <language>en</language>
           <script>Latn</script>
           <status>
-            <stage abbreviation="IS">60</stage>
+            <stage abbreviation="EXT">60</stage>
             <substage>60</substage>
           </status>
           <copyright>

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Metanorma::Iso do
         <title language="fr" type="title-part-prefix">Partie 1</title>
         <docidentifier type="ISO" primary="true">ISO/WD 1000-1.3:2000</docidentifier>
         <docidentifier type="iso-reference">ISO/WD 1000-1.3:2000(E)</docidentifier>
-        <docidentifier type='URN'>urn:iso:std:iso:1000:-1:stage-20.20.v3:en</docidentifier>
+        <docidentifier type='URN'>urn:iso:std:iso:1000:-1:WD.3:en</docidentifier>
         <docidentifier type='iso-undated'>ISO/WD 1000-1.3</docidentifier>
         <docidentifier type="iso-with-lang">ISO/WD 1000-1.3:2000(en)</docidentifier>
         <docnumber>1000</docnumber>
@@ -240,7 +240,7 @@ RSpec.describe Metanorma::Iso do
                 <project-number part="1">ISO 1000</project-number>
              </structuredidentifier>
              <horizontal>true</horizontal>
-             <stagename abbreviation="WD">Working Draft International Standard</stagename>
+             <stagename abbreviation="WD">Working Draft for International Standard</stagename>
              <fast-track>true</fast-track>
              <price-code>XC</price-code>
              <iso-cen-parallel>true</iso-cen-parallel>
@@ -304,8 +304,8 @@ RSpec.describe Metanorma::Iso do
           <title language="fr" type="title-complementary">Complement du Titre</title>
           <title language="fr" type="title-part-prefix">Partie 1–1</title>
           <docidentifier type="ISO" primary="true">IEC/IETF/ISO TR 1000-1-1:2001</docidentifier>
-          <docidentifier type="iso-reference">IEC/IETF/ISO TR 1000-1-1:2001()</docidentifier>
-          <docidentifier type="URN">urn:iso:std:iec-ietf-iso:tr:1000:-1-1:stage-60.60:el</docidentifier>
+          <docidentifier type="iso-reference">IEC/IETF/ISO TR 1000-1-1:2001(el)</docidentifier>
+          <docidentifier type="URN">urn:iso:std:iec-ietf-iso:tr:1000:-1-1:el</docidentifier>
           <docidentifier type="iso-undated">IEC/IETF/ISO TR 1000-1-1</docidentifier>
           <docidentifier type="iso-with-lang">IEC/IETF/ISO TR 1000-1-1:2001(el)</docidentifier>
           <docidentifier type="iso-tc">2000</docidentifier>
@@ -404,7 +404,7 @@ RSpec.describe Metanorma::Iso do
           <language>el</language>
           <script>Grek</script>
           <status>
-             <stage abbreviation="IS">60</stage>
+             <stage abbreviation="TR">60</stage>
              <substage>60</substage>
           </status>
           <copyright>
@@ -430,7 +430,7 @@ RSpec.describe Metanorma::Iso do
              <structuredidentifier>
                 <project-number part="1" subpart="1">IEC/IETF/ISO 1000</project-number>
              </structuredidentifier>
-             <stagename abbreviation="TR">Technical Report</stagename>
+             <stagename abbreviation="TR">Published Technical Report</stagename>
           </ext>
        </bibdata>
     OUTPUT
@@ -440,7 +440,7 @@ RSpec.describe Metanorma::Iso do
   end
 
   it "processes full publisher names" do
-    xml = Nokogiri::XML(Asciidoctor.convert(<<~"INPUT", *OPTIONS))
+    xml = Nokogiri::XML(Asciidoctor.convert(<<~INPUT, *OPTIONS))
       = Document title
       Author
       :docfile: test.adoc
@@ -455,7 +455,7 @@ RSpec.describe Metanorma::Iso do
           <bibdata type="standard">
         <docidentifier type="ISO" primary="true">ISO/IEC TR 1000:#{Date.today.year}</docidentifier>
         <docidentifier type="iso-reference">ISO/IEC TR 1000:#{Date.today.year}(E)</docidentifier>
-        <docidentifier type="URN">urn:iso:std:iso-iec:tr:1000:stage-60.60:en</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso-iec:tr:1000:en</docidentifier>
         <docidentifier type="iso-undated">ISO/IEC TR 1000</docidentifier>
         <docidentifier type="iso-with-lang">ISO/IEC TR 1000:#{Date.today.year}(en)</docidentifier>
         <docnumber>1000</docnumber>
@@ -498,7 +498,7 @@ RSpec.describe Metanorma::Iso do
         <language>en</language>
         <script>Latn</script>
         <status>
-          <stage abbreviation="IS">60</stage>
+          <stage abbreviation="TR">60</stage>
           <substage>60</substage>
         </status>
         <copyright>
@@ -525,7 +525,7 @@ RSpec.describe Metanorma::Iso do
           <structuredidentifier>
             <project-number>ISO/IEC 1000</project-number>
           </structuredidentifier>
-          <stagename abbreviation="TR">Technical Report</stagename>
+          <stagename abbreviation="TR">Published Technical Report</stagename>
         </ext>
       </bibdata>
     OUTPUT
@@ -560,154 +560,154 @@ RSpec.describe Metanorma::Iso do
 
     INPUT
     output = <<~OUTPUT
-       <bibdata type="standard">
-          <docidentifier type="ISO" primary="true">EXP 1000:#{Date.today.year}</docidentifier>
-          <docidentifier type="iso-reference">EXP 1000:#{Date.today.year}(E)</docidentifier>
-          <docidentifier type="URN">urn:iso:std:exp:1000:stage-60.60:en</docidentifier>
-          <docidentifier type="iso-undated">EXP 1000</docidentifier>
-          <docidentifier type="iso-with-lang">EXP 1000:#{Date.today.year}(en)</docidentifier>
-          <docnumber>1000</docnumber>
-          <contributor>
-             <role type="author"/>
-             <organization>
-                <name>EXPRESS Foundation</name>
-                <abbreviation>EXP</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="author">
-                <description>committee</description>
-             </role>
-             <organization>
-                <name>International Electrotechnical Commission</name>
-                <subdivision type="Technical committee" subtype="TC">
-                   <name>Electrical equipment in medical practice</name>
-                   <identifier>TC 62</identifier>
-                   <identifier type="full">IEC TC 62</identifier>
-                </subdivision>
-                <abbreviation>IEC</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="author">
-                <description>committee</description>
-             </role>
-             <organization>
-                <name>EXPRESS Foundation</name>
-                <subdivision type="Technical committee" subtype="TC">
-                   <name>Quality management and corresponding general aspects for medical devices</name>
-                   <identifier>TC 210</identifier>
-                   <identifier type="full">TC 210/SC 62A/WG 62A1</identifier>
-                </subdivision>
-                <subdivision type="Subcommittee" subtype="SC">
-                   <name>Common aspects of electrical equipment used in medical practice</name>
-                   <identifier>SC 62A</identifier>
-                </subdivision>
-                <subdivision type="Workgroup" subtype="WG">
-                   <name>Working group on defibulators</name>
-                   <identifier>WG 62A1</identifier>
-                </subdivision>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="author">
-                <description>committee</description>
-             </role>
-             <organization>
-                <name>Institute of Electrical and Electronic Engineers</name>
-                <subdivision type="Technical committee" subtype="TC">
-                   <name>The committee</name>
-                </subdivision>
-                <abbreviation>IEEE</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="authorizer">
-                <description>Agency</description>
-             </role>
-             <organization>
-                <name>EXPRESS Foundation</name>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="publisher"/>
-             <organization>
-                <name>EXPRESS Foundation</name>
-                <abbreviation>EXP</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="authorizer">
-                <description>committee</description>
-             </role>
-             <organization>
-                <name>International Electrotechnical Commission</name>
-                <subdivision type="Technical committee" subtype="TC">
-                   <name>Electrical equipment in medical practice</name>
-                   <identifier>TC 62</identifier>
-                   <identifier type="full">IEC TC 62</identifier>
-                </subdivision>
-                <abbreviation>IEC</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="authorizer">
-                <description>committee</description>
-             </role>
-             <organization>
-                <name>International Organization for Standardization</name>
-                <subdivision type="Technical committee" subtype="TC">
-                   <name>Quality management and corresponding general aspects for medical devices</name>
-                   <identifier>TC 210</identifier>
-                   <identifier type="full">TC 210/SC 62A/WG 62A1</identifier>
-                </subdivision>
-                <subdivision type="Subcommittee" subtype="SC">
-                   <name>Common aspects of electrical equipment used in medical practice</name>
-                   <identifier>SC 62A</identifier>
-                </subdivision>
-                <subdivision type="Workgroup" subtype="WG">
-                   <name>Working group on defibulators</name>
-                   <identifier>WG 62A1</identifier>
-                </subdivision>
-                <abbreviation>ISO</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="authorizer">
-                <description>committee</description>
-             </role>
-             <organization>
-                <name>Institute of Electrical and Electronic Engineers</name>
-                <subdivision type="Technical committee" subtype="TC">
-                   <name>The committee</name>
-                </subdivision>
-                <abbreviation>IEEE</abbreviation>
-             </organization>
-          </contributor>
-          <language>en</language>
-          <script>Latn</script>
-          <status>
-             <stage abbreviation="IS">60</stage>
-             <substage>60</substage>
-          </status>
-          <copyright>
-             <from>#{Date.today.year}</from>
-             <owner>
-                <organization>
-                   <name>EXPRESS Foundation</name>
-                   <abbreviation>EXP</abbreviation>
-                </organization>
-             </owner>
-          </copyright>
-          <ext>
-             <doctype>standard</doctype>
-             <flavor>iso</flavor>
-             <structuredidentifier>
-                <project-number>EXP 1000</project-number>
-             </structuredidentifier>
-             <stagename abbreviation="IS">International Standard</stagename>
-          </ext>
-       </bibdata>
+      <bibdata type="standard">
+         <docidentifier type="ISO" primary="true">EXP 1000:#{Date.today.year}</docidentifier>
+         <docidentifier type="iso-reference">EXP 1000:#{Date.today.year}(E)</docidentifier>
+         <docidentifier type="URN">urn:iso:std:exp:1000:en</docidentifier>
+         <docidentifier type="iso-undated">EXP 1000</docidentifier>
+         <docidentifier type="iso-with-lang">EXP 1000:#{Date.today.year}(en)</docidentifier>
+         <docnumber>1000</docnumber>
+         <contributor>
+            <role type="author"/>
+            <organization>
+               <name>EXPRESS Foundation</name>
+               <abbreviation>EXP</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="author">
+               <description>committee</description>
+            </role>
+            <organization>
+               <name>International Electrotechnical Commission</name>
+               <subdivision type="Technical committee" subtype="TC">
+                  <name>Electrical equipment in medical practice</name>
+                  <identifier>TC 62</identifier>
+                  <identifier type="full">IEC TC 62</identifier>
+               </subdivision>
+               <abbreviation>IEC</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="author">
+               <description>committee</description>
+            </role>
+            <organization>
+               <name>EXPRESS Foundation</name>
+               <subdivision type="Technical committee" subtype="TC">
+                  <name>Quality management and corresponding general aspects for medical devices</name>
+                  <identifier>TC 210</identifier>
+                  <identifier type="full">TC 210/SC 62A/WG 62A1</identifier>
+               </subdivision>
+               <subdivision type="Subcommittee" subtype="SC">
+                  <name>Common aspects of electrical equipment used in medical practice</name>
+                  <identifier>SC 62A</identifier>
+               </subdivision>
+               <subdivision type="Workgroup" subtype="WG">
+                  <name>Working group on defibulators</name>
+                  <identifier>WG 62A1</identifier>
+               </subdivision>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="author">
+               <description>committee</description>
+            </role>
+            <organization>
+               <name>Institute of Electrical and Electronic Engineers</name>
+               <subdivision type="Technical committee" subtype="TC">
+                  <name>The committee</name>
+               </subdivision>
+               <abbreviation>IEEE</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="authorizer">
+               <description>Agency</description>
+            </role>
+            <organization>
+               <name>EXPRESS Foundation</name>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="publisher"/>
+            <organization>
+               <name>EXPRESS Foundation</name>
+               <abbreviation>EXP</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="authorizer">
+               <description>committee</description>
+            </role>
+            <organization>
+               <name>International Electrotechnical Commission</name>
+               <subdivision type="Technical committee" subtype="TC">
+                  <name>Electrical equipment in medical practice</name>
+                  <identifier>TC 62</identifier>
+                  <identifier type="full">IEC TC 62</identifier>
+               </subdivision>
+               <abbreviation>IEC</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="authorizer">
+               <description>committee</description>
+            </role>
+            <organization>
+               <name>International Organization for Standardization</name>
+               <subdivision type="Technical committee" subtype="TC">
+                  <name>Quality management and corresponding general aspects for medical devices</name>
+                  <identifier>TC 210</identifier>
+                  <identifier type="full">TC 210/SC 62A/WG 62A1</identifier>
+               </subdivision>
+               <subdivision type="Subcommittee" subtype="SC">
+                  <name>Common aspects of electrical equipment used in medical practice</name>
+                  <identifier>SC 62A</identifier>
+               </subdivision>
+               <subdivision type="Workgroup" subtype="WG">
+                  <name>Working group on defibulators</name>
+                  <identifier>WG 62A1</identifier>
+               </subdivision>
+               <abbreviation>ISO</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="authorizer">
+               <description>committee</description>
+            </role>
+            <organization>
+               <name>Institute of Electrical and Electronic Engineers</name>
+               <subdivision type="Technical committee" subtype="TC">
+                  <name>The committee</name>
+               </subdivision>
+               <abbreviation>IEEE</abbreviation>
+            </organization>
+         </contributor>
+         <language>en</language>
+         <script>Latn</script>
+         <status>
+            <stage abbreviation="IS">60</stage>
+            <substage>60</substage>
+         </status>
+         <copyright>
+            <from>#{Date.today.year}</from>
+            <owner>
+               <organization>
+                  <name>EXPRESS Foundation</name>
+                  <abbreviation>EXP</abbreviation>
+               </organization>
+            </owner>
+         </copyright>
+         <ext>
+            <doctype>standard</doctype>
+            <flavor>iso</flavor>
+            <structuredidentifier>
+               <project-number>EXP 1000</project-number>
+            </structuredidentifier>
+            <stagename abbreviation="IS">International Standard</stagename>
+         </ext>
+      </bibdata>
     OUTPUT
     xml = xml.at("//xmlns:bibdata")
     expect(strip_guid(xml.to_xml))
@@ -743,104 +743,104 @@ RSpec.describe Metanorma::Iso do
       :approval-workgroup-type: Other
     INPUT
     output = <<~OUTPUT
-            <bibdata type="standard">
-        <docidentifier type="ISO" primary="true">ISO 1000:#{Date.today.year}</docidentifier>
-        <docidentifier type="iso-reference">ISO 1000:#{Date.today.year}(E)</docidentifier>
-        <docidentifier type="URN">urn:iso:std:iso:1000:stage-60.60:en</docidentifier>
-        <docidentifier type="iso-undated">ISO 1000</docidentifier>
-        <docidentifier type="iso-with-lang">ISO 1000:#{Date.today.year}(en)</docidentifier>
-        <docnumber>1000</docnumber>
-          <contributor>
-             <role type="author"/>
-             <organization>
-                <name>International Organization for Standardization</name>
-                <abbreviation>ISO</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="author">
-                <description>committee</description>
-             </role>
-             <organization>
-                <name>International Organization for Standardization</name>
-                <subdivision type="Technical committee" subtype="Other">
-                   <name>Techcomm</name>
-                   <identifier>1</identifier>
-                   <identifier type="full">1/2/3</identifier>
-                </subdivision>
-                <subdivision type="Subcommittee" subtype="Other">
-                   <name>Subcommitt</name>
-                   <identifier>2</identifier>
-                </subdivision>
-                <subdivision type="Workgroup" subtype="Other">
-                   <name>Workg</name>
-                   <identifier>3</identifier>
-                </subdivision>
-                <abbreviation>ISO</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="authorizer">
-                <description>Agency</description>
-             </role>
-             <organization>
-                <name>International Organization for Standardization</name>
-                <abbreviation>ISO</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="publisher"/>
-             <organization>
-                <name>International Organization for Standardization</name>
-                <abbreviation>ISO</abbreviation>
-             </organization>
-          </contributor>
-          <contributor>
-             <role type="authorizer">
-                <description>committee</description>
-             </role>
-             <organization>
-                <name>International Organization for Standardization</name>
-                <subdivision type="Technical committee" subtype="Other">
-                   <name>ApprovTechcom</name>
-                   <identifier>1</identifier>
-                   <identifier type="full">1/2/3</identifier>
-                </subdivision>
-                <subdivision type="Subcommittee" subtype="Other">
-                   <name>ApprovSubcom</name>
-                   <identifier>2</identifier>
-                </subdivision>
-                <subdivision type="Workgroup" subtype="Other">
-                   <name>ApprovWorkg</name>
-                   <identifier>3</identifier>
-                </subdivision>
-                <abbreviation>ISO</abbreviation>
-             </organization>
-          </contributor>
-          <language>en</language>
-          <script>Latn</script>
-          <status>
-             <stage abbreviation="IS">60</stage>
-             <substage>60</substage>
-          </status>
-          <copyright>
-             <from>#{Date.today.year}</from>
-             <owner>
-                <organization>
-                   <name>International Organization for Standardization</name>
-                   <abbreviation>ISO</abbreviation>
-                </organization>
-             </owner>
-          </copyright>
-          <ext>
-             <doctype>standard</doctype>
-             <flavor>iso</flavor>
-             <structuredidentifier>
-                <project-number>ISO 1000</project-number>
-             </structuredidentifier>
-             <stagename abbreviation="IS">International Standard</stagename>
-          </ext>
-       </bibdata>
+           <bibdata type="standard">
+       <docidentifier type="ISO" primary="true">ISO 1000:#{Date.today.year}</docidentifier>
+       <docidentifier type="iso-reference">ISO 1000:#{Date.today.year}(E)</docidentifier>
+       <docidentifier type="URN">urn:iso:std:iso:1000:en</docidentifier>
+       <docidentifier type="iso-undated">ISO 1000</docidentifier>
+       <docidentifier type="iso-with-lang">ISO 1000:#{Date.today.year}(en)</docidentifier>
+       <docnumber>1000</docnumber>
+         <contributor>
+            <role type="author"/>
+            <organization>
+               <name>International Organization for Standardization</name>
+               <abbreviation>ISO</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="author">
+               <description>committee</description>
+            </role>
+            <organization>
+               <name>International Organization for Standardization</name>
+               <subdivision type="Technical committee" subtype="Other">
+                  <name>Techcomm</name>
+                  <identifier>1</identifier>
+                  <identifier type="full">1/2/3</identifier>
+               </subdivision>
+               <subdivision type="Subcommittee" subtype="Other">
+                  <name>Subcommitt</name>
+                  <identifier>2</identifier>
+               </subdivision>
+               <subdivision type="Workgroup" subtype="Other">
+                  <name>Workg</name>
+                  <identifier>3</identifier>
+               </subdivision>
+               <abbreviation>ISO</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="authorizer">
+               <description>Agency</description>
+            </role>
+            <organization>
+               <name>International Organization for Standardization</name>
+               <abbreviation>ISO</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="publisher"/>
+            <organization>
+               <name>International Organization for Standardization</name>
+               <abbreviation>ISO</abbreviation>
+            </organization>
+         </contributor>
+         <contributor>
+            <role type="authorizer">
+               <description>committee</description>
+            </role>
+            <organization>
+               <name>International Organization for Standardization</name>
+               <subdivision type="Technical committee" subtype="Other">
+                  <name>ApprovTechcom</name>
+                  <identifier>1</identifier>
+                  <identifier type="full">1/2/3</identifier>
+               </subdivision>
+               <subdivision type="Subcommittee" subtype="Other">
+                  <name>ApprovSubcom</name>
+                  <identifier>2</identifier>
+               </subdivision>
+               <subdivision type="Workgroup" subtype="Other">
+                  <name>ApprovWorkg</name>
+                  <identifier>3</identifier>
+               </subdivision>
+               <abbreviation>ISO</abbreviation>
+            </organization>
+         </contributor>
+         <language>en</language>
+         <script>Latn</script>
+         <status>
+            <stage abbreviation="IS">60</stage>
+            <substage>60</substage>
+         </status>
+         <copyright>
+            <from>#{Date.today.year}</from>
+            <owner>
+               <organization>
+                  <name>International Organization for Standardization</name>
+                  <abbreviation>ISO</abbreviation>
+               </organization>
+            </owner>
+         </copyright>
+         <ext>
+            <doctype>standard</doctype>
+            <flavor>iso</flavor>
+            <structuredidentifier>
+               <project-number>ISO 1000</project-number>
+            </structuredidentifier>
+            <stagename abbreviation="IS">International Standard</stagename>
+         </ext>
+      </bibdata>
     OUTPUT
     xml = xml.at("//xmlns:bibdata")
     expect(strip_guid(xml.to_xml))
@@ -873,7 +873,7 @@ RSpec.describe Metanorma::Iso do
       <bibdata type="standard">
         <docidentifier type="ISO" primary="true">ISO 1000:#{Date.today.year}</docidentifier>
         <docidentifier type="iso-reference">ISO 1000:#{Date.today.year}(E)</docidentifier>
-        <docidentifier type="URN">urn:iso:std:iso:1000:stage-60.60:en</docidentifier>
+        <docidentifier type="URN">urn:iso:std:iso:1000:en</docidentifier>
         <docidentifier type="iso-undated">ISO 1000</docidentifier>
         <docidentifier type="iso-with-lang">ISO 1000:#{Date.today.year}(en)</docidentifier>
         <docnumber>1000</docnumber>
@@ -987,7 +987,7 @@ RSpec.describe Metanorma::Iso do
       <bibdata type='standard'>
         <docidentifier type='ISO' primary="true">ISO/FDTS 1000-1-1:2001</docidentifier>
         <docidentifier type='iso-reference'>ISO/FDTS 1000-1-1:2001(E)</docidentifier>
-        <docidentifier type='URN'>urn:iso:std:iso:ts:1000:-1-1:stage-50.00:en</docidentifier>
+        <docidentifier type='URN'>urn:iso:std:iso:ts:1000:-1-1:FDTS:en</docidentifier>
         <docidentifier type='iso-undated'>ISO/FDTS 1000-1-1</docidentifier>
         <docidentifier type='iso-with-lang'>ISO/FDTS 1000-1-1:2001(en)</docidentifier>
         <docnumber>1000</docnumber>
@@ -1227,10 +1227,10 @@ RSpec.describe Metanorma::Iso do
         <ext>
           <doctype>standard</doctype>
                 <flavor>iso</flavor>
-          <horizontal>true</horizontal>
           <structuredidentifier>
             <project-number part='1'>ISO 1000</project-number>
           </structuredidentifier>
+          <horizontal>true</horizontal>
           <stagename abbreviation="IS">International Standard</stagename>
         </ext>
       </bibdata>
@@ -1457,7 +1457,7 @@ RSpec.describe Metanorma::Iso do
       <bibdata type="standard">
         <docidentifier type="ISO" primary="true">ISO 1000:#{Date.today.year}</docidentifier>
         <docidentifier type='iso-reference'>ISO 1000:#{Date.today.year}(E)</docidentifier>
-        <docidentifier type='URN'>urn:iso:std:iso:1000:stage-60.60:en</docidentifier>
+        <docidentifier type='URN'>urn:iso:std:iso:1000:en</docidentifier>
         <docidentifier type='iso-undated'>ISO 1000</docidentifier>
         <docidentifier type='iso-with-lang'>ISO 1000:#{Date.today.year}(en)</docidentifier>
         <docnumber>1000</docnumber>
@@ -2041,18 +2041,18 @@ RSpec.describe Metanorma::Iso do
       :document-scheme: DOCUMENT-SCHEME
     INPUT
     output = <<~OUTPUT
-      <metanorma-extension>
-        <semantic-metadata>
-            <stage-published>true</stage-published>
-        </semantic-metadata>
-         <presentation-metadata>
-           <document-scheme>DOCUMENT-SCHEME</document-scheme>
-      <toc-heading-levels>2</toc-heading-levels>
-      <html-toc-heading-levels>2</html-toc-heading-levels>
-      <doc-toc-heading-levels>3</doc-toc-heading-levels>
-      <pdf-toc-heading-levels>3</pdf-toc-heading-levels>
-    </presentation-metadata>
-       </metanorma-extension>
+        <metanorma-extension>
+          <semantic-metadata>
+              <stage-published>true</stage-published>
+          </semantic-metadata>
+           <presentation-metadata>
+             <document-scheme>DOCUMENT-SCHEME</document-scheme>
+        <toc-heading-levels>2</toc-heading-levels>
+        <html-toc-heading-levels>2</html-toc-heading-levels>
+        <doc-toc-heading-levels>3</doc-toc-heading-levels>
+        <pdf-toc-heading-levels>3</pdf-toc-heading-levels>
+      </presentation-metadata>
+         </metanorma-extension>
     OUTPUT
     expect(strip_guid(Nokogiri::XML(Asciidoctor
       .convert(input, *OPTIONS))

--- a/spec/metanorma/refs_spec.rb
+++ b/spec/metanorma/refs_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Metanorma::Iso do
                    </contributor>
                    <edition>1</edition>
                    <note type="Unpublished-Status">
-                      <p id="_">Under preparation. Stage at the time of publication: IEC PWI 100-44:#{Date.today.year} ED1.</p>
+                      <p id="_">Under preparation. Stage at the time of publication: IEC/PWI 100-44:#{Date.today.year} ED1.</p>
                    </note>
                    <language>en</language>
                    <language>fr</language>

--- a/spec/sts/inline_transformer_spec.rb
+++ b/spec/sts/inline_transformer_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Metanorma::Iso::Sts::Transformer::InlineTransformer do
       locality.type = "clause"
       locality.reference_from = "3.1"
       locality_stack = Metanorma::Document::Relaton::LocalityStack.new
-      locality_stack.bib_locality = [locality]
+      locality_stack.locality = [locality]
       eref.locality_stack = [locality_stack]
 
       result = transformer.send(:transform_eref, eref)


### PR DESCRIPTION
## Summary
Cherry-picks the four pubid-2 commits from the model-migration branch onto main, plus the `pubid "~> 2.0"` contract:
- `Migrate converter to pubid 2` — `pubid_select(...).create(**)` → the `locate_type(...).new(**)` construction; `Pubid::Cen` → the monogem's `Pubid::CenCenelec`
- `Adopt pubid@main: undated-reference support and base rename`
- `Update specs, adapter and docs for the pubid-2 chain` (spec snapshots taken from the branch; Gemfile cross-PR pins NOT carried)
- `Dispatch pubid registry by publisher in iso_pubid_create`

## Hold gate
`~> 2.0` resolves nothing until pubid 2.0.0 final ships (2.x is prerelease-only). Do not merge until then.

## Verification (local, chain as path deps: isodoc#842 + standoc#1242 + this, pubid `2.0.0.pre.alpha.8`, relaton-cli `3.0.0.pre.alpha.1`)
149 examples, **1 failure** — the cross-flavor `inline_spec` ITU docid-annotation fixture, which fails identically on the model-migration branch (known pending fixture for the pubid-2 chain, not a regression of this PR). Fixture update to land before merge.

## Chain
isodoc#842 · metanorma-standoc#1242 · metanorma-itu#844 · iec PR (follows) · ieee + nist ports remain
